### PR TITLE
Development

### DIFF
--- a/migrations/import-wp/constants.ts
+++ b/migrations/import-wp/constants.ts
@@ -1,3 +1,3 @@
 // Replace this with your WordPress site's WP-JSON REST API URL
-export const BASE_URL = `https://public-api.wordpress.com/rest/v1.1/sites/haramizujp.wordpress.com`
+export const BASE_URL = `https://public-api.wordpress.com/wp/v2/sites/haramizujp.wordpress.com`
 export const PER_PAGE = 100

--- a/migrations/import-wp/constants.ts
+++ b/migrations/import-wp/constants.ts
@@ -1,0 +1,3 @@
+// Replace this with your WordPress site's WP-JSON REST API URL
+export const BASE_URL = `https://public-api.wordpress.com/rest/v1.1/sites/haramizujp.wordpress.com`
+export const PER_PAGE = 100

--- a/migrations/import-wp/index.ts
+++ b/migrations/import-wp/index.ts
@@ -1,0 +1,58 @@
+import {at, defineMigration, setIfMissing, unset} from 'sanity/migrate'
+
+export default defineMigration({
+  title: 'Import WP',
+
+  migrate: {
+    document(doc, context) {
+      // this will be called for every document of the matching type
+      // any patch returned will be applied to the document
+      // you can also return mutations that touches other documents
+
+      return at('title', setIfMissing('Default title'))
+    },
+    node(node, path, context) {
+      // this will be called for every node in every document of the matching type
+      // any patch returned will be applied to the document
+      // you can also return mutations that touches other documents
+
+      if (typeof node === 'string' && node === 'deleteme') {
+        return unset()
+      }
+    },
+    object(node, path, context) {
+      // this will be called for every object node in every document of the matching type
+      // any patch returned will be applied to the document
+      // you can also return mutations that touches other documents
+      if (node._type === 'author') {
+        // make sure all authors objects have a books array
+        return at('books', setIfMissing([]))
+      }
+    },
+    array(node, path, context) {
+      // this will be called for every array node in every document of the matching type
+      // any patch returned will be applied to the document
+      // you can also return mutations that touches other documents
+    },
+    string(node, path, context) {
+      // this will be called for every string node in every document of the matching type
+      // any patch returned will be applied to the document
+      // you can also return mutations that touches other documents
+    },
+    number(node, path, context) {
+      // this will be called for every number node in every document of the matching type
+      // any patch returned will be applied to the document
+      // you can also return mutations that touches other documents
+    },
+    boolean(node, path, context) {
+      // this will be called for every boolean node in every document of the matching type
+      // any patch returned will be applied to the document
+      // you can also return mutations that touches other documents
+    },
+    null(node, path, context) {
+      // this will be called for every null node in every document of the matching type
+      // any patch returned will be applied to the document
+      // you can also return mutations that touches other documents
+    },
+  },
+})

--- a/migrations/import-wp/index.ts
+++ b/migrations/import-wp/index.ts
@@ -1,58 +1,44 @@
-import {at, defineMigration, setIfMissing, unset} from 'sanity/migrate'
+import type {SanityDocumentLike} from 'sanity'
+import {createOrReplace, defineMigration} from 'sanity/migrate'
 
+import {wpDataTypeFetch} from './lib/wpDataTypeFetch'
+
+// This will import `post` documents into Sanity from the WordPress API
 export default defineMigration({
   title: 'Import WP',
 
-  migrate: {
-    document(doc, context) {
-      // this will be called for every document of the matching type
-      // any patch returned will be applied to the document
-      // you can also return mutations that touches other documents
+  async *migrate() {
+    const wpType = 'posts'
+    let page = 1
+    let hasMore = true
 
-      return at('title', setIfMissing('Default title'))
-    },
-    node(node, path, context) {
-      // this will be called for every node in every document of the matching type
-      // any patch returned will be applied to the document
-      // you can also return mutations that touches other documents
+    while (hasMore) {
+      try {
+        const wpData = await wpDataTypeFetch(wpType, page)
 
-      if (typeof node === 'string' && node === 'deleteme') {
-        return unset()
+        if (Array.isArray(wpData) && wpData.length) {
+          const docs: SanityDocumentLike[] = []
+
+          for (const wpDoc of wpData) {
+            const doc: SanityDocumentLike = {
+              _id: `post-${wpDoc.id}`,
+              _type: 'post',
+              title: wpDoc.title?.rendered.trim(),
+            }
+
+            docs.push(doc)
+          }
+
+          yield docs.map((doc) => createOrReplace(doc))
+          page++
+        } else {
+          hasMore = false
+        }
+      } catch (error) {
+        console.error(`Error fetching data for page ${page}:`, error)
+        // Stop the loop in case of an error
+        hasMore = false
       }
-    },
-    object(node, path, context) {
-      // this will be called for every object node in every document of the matching type
-      // any patch returned will be applied to the document
-      // you can also return mutations that touches other documents
-      if (node._type === 'author') {
-        // make sure all authors objects have a books array
-        return at('books', setIfMissing([]))
-      }
-    },
-    array(node, path, context) {
-      // this will be called for every array node in every document of the matching type
-      // any patch returned will be applied to the document
-      // you can also return mutations that touches other documents
-    },
-    string(node, path, context) {
-      // this will be called for every string node in every document of the matching type
-      // any patch returned will be applied to the document
-      // you can also return mutations that touches other documents
-    },
-    number(node, path, context) {
-      // this will be called for every number node in every document of the matching type
-      // any patch returned will be applied to the document
-      // you can also return mutations that touches other documents
-    },
-    boolean(node, path, context) {
-      // this will be called for every boolean node in every document of the matching type
-      // any patch returned will be applied to the document
-      // you can also return mutations that touches other documents
-    },
-    null(node, path, context) {
-      // this will be called for every null node in every document of the matching type
-      // any patch returned will be applied to the document
-      // you can also return mutations that touches other documents
-    },
+    }
   },
 })

--- a/migrations/import-wp/lib/wpDataTypeFetch.ts
+++ b/migrations/import-wp/lib/wpDataTypeFetch.ts
@@ -1,0 +1,13 @@
+import {BASE_URL, PER_PAGE} from '../constants'
+import type {WordPressDataType, WordPressDataTypeResponses} from '../types'
+
+export async function wpDataTypeFetch<T extends WordPressDataType>(
+  type: T,
+  page: number,
+): Promise<WordPressDataTypeResponses[T]> {
+  const wpApiUrl = new URL(`${BASE_URL}/${type}`)
+  wpApiUrl.searchParams.set('page', page.toString())
+  wpApiUrl.searchParams.set('per_page', PER_PAGE.toString())
+
+  return fetch(wpApiUrl).then((res) => (res.ok ? res.json() : null))
+}

--- a/migrations/import-wp/types.ts
+++ b/migrations/import-wp/types.ts
@@ -1,0 +1,19 @@
+import type {
+  WP_REST_API_Categories,
+  WP_REST_API_Pages,
+  WP_REST_API_Posts,
+  WP_REST_API_Tags,
+  WP_REST_API_Users,
+} from 'wp-types'
+
+export type WordPressDataType = 'categories' | 'posts' | 'pages' | 'tags' | 'users'
+
+export type WordPressDataTypeResponses = {
+  categories: WP_REST_API_Categories
+  posts: WP_REST_API_Posts
+  pages: WP_REST_API_Pages
+  tags: WP_REST_API_Tags
+  users: WP_REST_API_Users
+}
+
+export type SanitySchemaType = 'category' | 'post' | 'page' | 'tag' | 'author'

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,18 +10,24 @@
       "license": "UNLICENSED",
       "dependencies": {
         "@sanity/icons": "^3.7.4",
-        "@sanity/vision": "^4.6.0",
+        "@sanity/vision": "^4.8.1",
         "react": "^19.1",
         "react-dom": "^19.1",
-        "sanity": "^4.6.0",
+        "sanity": "^4.8.1",
         "styled-components": "^6.1.18"
       },
       "devDependencies": {
+        "@portabletext/block-tools": "^3.5.5",
         "@sanity/eslint-config-studio": "^5.0.2",
         "@types/react": "^19.1",
+        "@wordpress/block-serialization-default-parser": "^5.30.0",
         "eslint": "^9.28",
+        "html-entities": "^2.6.0",
+        "jsdom": "^26.1.0",
+        "p-limit": "^7.1.1",
         "prettier": "^3.5",
-        "typescript": "^5.8"
+        "typescript": "^5.8",
+        "wp-types": "^4.68.1"
       }
     },
     "node_modules/@actions/core": {
@@ -73,19 +79,6 @@
       "resolved": "https://registry.npmjs.org/@actions/io/-/io-1.1.3.tgz",
       "integrity": "sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q==",
       "license": "MIT"
-    },
-    "node_modules/@ampproject/remapping": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
-      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.5",
-        "@jridgewell/trace-mapping": "^0.3.24"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
     },
     "node_modules/@architect/asap": {
       "version": "7.0.10",
@@ -318,21 +311,21 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.3.tgz",
-      "integrity": "sha512-yDBHV9kQNcr2/sUr9jghVyz9C3Y5G2zUM2H2lo+9mKv4sFgbA8s8Z9t8D1jiTkGoO/NoIfKMyKWr4s6CN23ZwQ==",
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.4.tgz",
+      "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "license": "MIT",
       "dependencies": {
-        "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
         "@babel/helper-compilation-targets": "^7.27.2",
         "@babel/helper-module-transforms": "^7.28.3",
-        "@babel/helpers": "^7.28.3",
-        "@babel/parser": "^7.28.3",
+        "@babel/helpers": "^7.28.4",
+        "@babel/parser": "^7.28.4",
         "@babel/template": "^7.27.2",
-        "@babel/traverse": "^7.28.3",
-        "@babel/types": "^7.28.2",
+        "@babel/traverse": "^7.28.4",
+        "@babel/types": "^7.28.4",
+        "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -627,25 +620,25 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.3.tgz",
-      "integrity": "sha512-PTNtvUQihsAsDHMOP5pfobP8C6CM4JWXmP8DrEIt46c3r2bf87Ua1zoqevsMo9g+tWDwgWrFP5EIxuBx5RudAw==",
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.4.tgz",
+      "integrity": "sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==",
       "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.27.2",
-        "@babel/types": "^7.28.2"
+        "@babel/types": "^7.28.4"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.3.tgz",
-      "integrity": "sha512-7+Ey1mAgYqFAx2h0RuoxcQT5+MlG3GTV0TQrgr7/ZliKsm/MNDxVVutlWaziMq7wJNAz8MTqz55XLpWvva6StA==",
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.4.tgz",
+      "integrity": "sha512-yZbBqeM6TkpP9du/I2pUZnJsRMGGvOuIrhjzC1AwHwW+6he4mni6Bp/m8ijn0iOuZuPI2BfkCoSRunpyjnrQKg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.28.2"
+        "@babel/types": "^7.28.4"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -886,9 +879,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-block-scoping": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.28.0.tgz",
-      "integrity": "sha512-gKKnwjpdx5sER/wl0WN0efUBFzF/56YZO0RJrSYP4CljXnP31ByY7fol89AzomdlLNzI36AvOTmYHsnZTCkq8Q==",
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.28.4.tgz",
+      "integrity": "sha512-1yxmvN0MJHOhPVmAsmoW5liWwoILobu/d/ShymZmj867bAdxGbehIrew1DuLpw2Ukv+qDSSPQdYW1dLNE7t11A==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -933,9 +926,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-classes": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.28.3.tgz",
-      "integrity": "sha512-DoEWC5SuxuARF2KdKmGUq3ghfPMO6ZzR12Dnp5gubwbeWJo4dbNWXJPVlwvh4Zlq6Z7YVvL8VFxeSOJgjsx4Sg==",
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.28.4.tgz",
+      "integrity": "sha512-cFOlhIYPBv/iBoc+KS3M6et2XPtbT2HiCRfBXWtfpc9OAyostldxIf9YAYB6ypURBBbx+Qv6nyrLzASfJe+hBA==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.27.3",
@@ -943,7 +936,7 @@
         "@babel/helper-globals": "^7.28.0",
         "@babel/helper-plugin-utils": "^7.27.1",
         "@babel/helper-replace-supers": "^7.27.1",
-        "@babel/traverse": "^7.28.3"
+        "@babel/traverse": "^7.28.4"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1313,16 +1306,16 @@
       }
     },
     "node_modules/@babel/plugin-transform-object-rest-spread": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.28.0.tgz",
-      "integrity": "sha512-9VNGikXxzu5eCiQjdE4IZn8sb9q7Xsk5EXLDBKUYg1e/Tve8/05+KJEtcxGxAgCY5t/BpKQM+JEL/yT4tvgiUA==",
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.28.4.tgz",
+      "integrity": "sha512-373KA2HQzKhQCYiRVIRr+3MjpCObqzDlyrM6u4I201wL8Mp2wHf7uB8GhDwis03k2ti8Zr65Zyyqs1xOxUF/Ew==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-compilation-targets": "^7.27.2",
         "@babel/helper-plugin-utils": "^7.27.1",
         "@babel/plugin-transform-destructuring": "^7.28.0",
         "@babel/plugin-transform-parameters": "^7.27.7",
-        "@babel/traverse": "^7.28.0"
+        "@babel/traverse": "^7.28.4"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1537,9 +1530,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-regenerator": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.28.3.tgz",
-      "integrity": "sha512-K3/M/a4+ESb5LEldjQb+XSrpY0nF+ZBFlTCbSnKaYAMfD8v33O6PMs4uYnOk19HlcsI8WMu3McdFPTiQHF/1/A==",
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.28.4.tgz",
+      "integrity": "sha512-+ZEdQlBoRg9m2NnzvEeLgtvBMO4tkFBw5SQIUgLICgTrumLoU7lr+Oghi6km2PFj+dbUt2u1oby2w3BDO9YQnA==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -1920,17 +1913,17 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.3.tgz",
-      "integrity": "sha512-7w4kZYHneL3A6NP2nxzHvT3HCZ7puDZZjFMqDpBPECub79sTtSO5CGXDkKrTQq8ksAwfD/XI2MRFX23njdDaIQ==",
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.4.tgz",
+      "integrity": "sha512-YEzuboP2qvQavAcjgQNVgsvHIDv6ZpwXvcvjmyySP2DIMuByS/6ioU5G9pYrWHM6T2YDfc7xga9iNzYOs12CFQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
         "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.28.3",
+        "@babel/parser": "^7.28.4",
         "@babel/template": "^7.27.2",
-        "@babel/types": "^7.28.2",
+        "@babel/types": "^7.28.4",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -1938,9 +1931,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.28.2",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.2.tgz",
-      "integrity": "sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==",
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.4.tgz",
+      "integrity": "sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
@@ -1951,9 +1944,9 @@
       }
     },
     "node_modules/@codemirror/autocomplete": {
-      "version": "6.18.6",
-      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.18.6.tgz",
-      "integrity": "sha512-PHHBXFomUs5DF+9tCOM/UoW6XQ4R44lLNNhRaW9PKPTU0D7lIjRg3ElxaJnTwsl/oHiR93WSXDBrekhoUGCPtg==",
+      "version": "6.18.7",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.18.7.tgz",
+      "integrity": "sha512-8EzdeIoWPJDsMBwz3zdzwXnUpCzMiCyz5/A3FIPpriaclFCGDkAzK13sMcnsu5rowqiyeQN2Vs2TsOcoDPZirQ==",
       "license": "MIT",
       "dependencies": {
         "@codemirror/language": "^6.0.0",
@@ -2047,9 +2040,9 @@
       }
     },
     "node_modules/@codemirror/view": {
-      "version": "6.38.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.38.1.tgz",
-      "integrity": "sha512-RmTOkE7hRU3OVREqFVITWHz6ocgBjv08GoePscAakgVQfciA3SGCEk7mb9IzwW61cKKmlTpHXG6DUE5Ubx+MGQ==",
+      "version": "6.38.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.38.2.tgz",
+      "integrity": "sha512-bTWAJxL6EOFLPzTx+O5P5xAO3gTqpatQ2b/ARQ8itfU/v2LlpS3pH2fkL0A3E/Fx8Y2St2KES7ZEV0sHTsSW/A==",
       "license": "MIT",
       "dependencies": {
         "@codemirror/state": "^6.5.0",
@@ -3406,6 +3399,15 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@isaacs/ttlcache": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/ttlcache/-/ttlcache-1.4.1.tgz",
+      "integrity": "sha512-RQgQ4uQ+pLbqXfOmieB91ejmLwvSgv9nLx6sT6sD83s7umBypgg+OIBOBbEUiJXrfpnp9j0mRhYYdzp9uqq3lA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -3413,6 +3415,16 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.24"
       }
     },
@@ -3498,25 +3510,25 @@
       }
     },
     "node_modules/@mux/mux-player": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/@mux/mux-player/-/mux-player-3.5.3.tgz",
-      "integrity": "sha512-uXKFXbdtioAi+clSVfD60Rw4r7OvA62u2jV6aar9loW9qMsmKv8LU+8uaIaWQjyAORp6E0S37GOVjo72T6O2eQ==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@mux/mux-player/-/mux-player-3.6.0.tgz",
+      "integrity": "sha512-yVWmTMJUoKNZZxsINFmz7ZUUR3GC+Qf7b6Qv2GTmUoYn14pO1aXywHLlMLDohstLIvdeOdh6F/WsD2/gDVSOmQ==",
       "license": "MIT",
       "dependencies": {
-        "@mux/mux-video": "0.26.1",
-        "@mux/playback-core": "0.30.1",
-        "media-chrome": "~4.11.1",
-        "player.style": "^0.1.9"
+        "@mux/mux-video": "0.27.0",
+        "@mux/playback-core": "0.31.0",
+        "media-chrome": "~4.13.1",
+        "player.style": "^0.2.0"
       }
     },
     "node_modules/@mux/mux-player-react": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/@mux/mux-player-react/-/mux-player-react-3.5.3.tgz",
-      "integrity": "sha512-f0McZbIXYDkzecFwhhkf0JgEInPnsOClgBqBhkdhRlLRdrAzMATib+D3Di3rPkRHNH7rc/WWORvSxgJz6m6zkA==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@mux/mux-player-react/-/mux-player-react-3.6.0.tgz",
+      "integrity": "sha512-bh2Z1fQqNkKCNUMS/3VU6jL2iY22155ZSIyizfz+bVX0EYHqdsS/iG95iDYLPlzA8WPyIh+J210tme68e1qP+w==",
       "license": "MIT",
       "dependencies": {
-        "@mux/mux-player": "3.5.3",
-        "@mux/playback-core": "0.30.1",
+        "@mux/mux-player": "3.6.0",
+        "@mux/playback-core": "0.31.0",
         "prop-types": "^15.8.1"
       },
       "peerDependencies": {
@@ -3533,23 +3545,39 @@
         }
       }
     },
+    "node_modules/@mux/mux-player/node_modules/player.style": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/player.style/-/player.style-0.2.0.tgz",
+      "integrity": "sha512-Ngoaz49TClptMr8HDA2IFmjT3Iq6R27QEUH/C+On33L59RSF3dCLefBYB1Au2RDZQJ6oVFpc1sXaPVpp7fEzzA==",
+      "license": "MIT",
+      "workspaces": [
+        ".",
+        "site",
+        "examples/*",
+        "scripts/*",
+        "themes/*"
+      ],
+      "dependencies": {
+        "media-chrome": "~4.13.0"
+      }
+    },
     "node_modules/@mux/mux-video": {
-      "version": "0.26.1",
-      "resolved": "https://registry.npmjs.org/@mux/mux-video/-/mux-video-0.26.1.tgz",
-      "integrity": "sha512-gkMdBAgNlB4+krANZHkQFzYWjWeNsJz69y1/hnPtmNQnpvW+O7oc71OffcZrbblyibSxWMQ6MQpYmBVjXlp6sA==",
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@mux/mux-video/-/mux-video-0.27.0.tgz",
+      "integrity": "sha512-Oi142YAcPKrmHTG+eaWHWaE7ucMHeJwx1FXABbLM2hMGj9MQ7kYjsD5J3meFlvuyz5UeVDsPLHeUJgeBXUZovg==",
       "license": "MIT",
       "dependencies": {
         "@mux/mux-data-google-ima": "0.2.8",
-        "@mux/playback-core": "0.30.1",
+        "@mux/playback-core": "0.31.0",
         "castable-video": "~1.1.10",
         "custom-media-element": "~1.4.5",
         "media-tracks": "~0.3.3"
       }
     },
     "node_modules/@mux/playback-core": {
-      "version": "0.30.1",
-      "resolved": "https://registry.npmjs.org/@mux/playback-core/-/playback-core-0.30.1.tgz",
-      "integrity": "sha512-rnO1NE9xHDyzbAkmE6ygJYcD7cyyMt7xXqWTykxlceaoSXLjUqgp42HDio7Lcidto4x/O4FIa7ztjV2aCBCXgQ==",
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@mux/playback-core/-/playback-core-0.31.0.tgz",
+      "integrity": "sha512-VADcrtS4O6fQBH8qmgavS6h7v7amzy2oCguu1NnLaVZ3Z8WccNXcF0s7jPRoRDyXWGShgtVhypW2uXjLpkPxyw==",
       "license": "MIT",
       "dependencies": {
         "hls.js": "~1.6.6",
@@ -3592,9 +3620,9 @@
       }
     },
     "node_modules/@oclif/core": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-4.5.2.tgz",
-      "integrity": "sha512-eQcKyrEcDYeZJKu4vUWiu0ii/1Gfev6GF4FsLSgNez5/+aQyAUCjg3ZWlurf491WiYZTXCWyKAxyPWk8DKv2MA==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-4.5.3.tgz",
+      "integrity": "sha512-ISoFlfmsuxJvNKXhabCO4/KqNXDQdLHchZdTPfZbtqAsQbqTw5IKitLVZq9Sz1LWizN37HILp4u0350B8scBjg==",
       "license": "MIT",
       "dependencies": {
         "ansi-escapes": "^4.3.2",
@@ -3852,28 +3880,28 @@
       }
     },
     "node_modules/@portabletext/block-tools": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@portabletext/block-tools/-/block-tools-3.5.1.tgz",
-      "integrity": "sha512-jyPHw+fMSMdbvBadE7lQ8HawQO9ZzM2m5OTieGN4yk0Z4iWxCb/X/sRtqb3qJYqspPuhZdn+DrveSE16/CBFaQ==",
+      "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/@portabletext/block-tools/-/block-tools-3.5.5.tgz",
+      "integrity": "sha512-LV/2NoUguY4CR69D4WKotOmrGy4DeUmMEij/CasdxeGXN4NVMUTGsN9dax2K1J8TDM3oRWhR9WmaJZG11nmmUw==",
       "license": "MIT",
       "dependencies": {
-        "@portabletext/sanity-bridge": "^1.1.7",
+        "@portabletext/sanity-bridge": "^1.1.9",
         "@portabletext/schema": "^1.2.0",
         "get-random-values-esm": "1.0.2",
         "lodash": "^4.17.21"
       },
       "peerDependencies": {
-        "@sanity/types": "^4.6.0",
+        "@sanity/types": "^4.8.1",
         "@types/react": "^18.3 || ^19"
       }
     },
     "node_modules/@portabletext/editor": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/@portabletext/editor/-/editor-2.6.7.tgz",
-      "integrity": "sha512-fAm/yQ21NnxYlKg1lqR4MEXx9aqmkrn9S5yHwg22IkAW6Gy5Oi8RTB14j27UCPf0EhvZFLKNzY0gzjjpAZoUpA==",
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@portabletext/editor/-/editor-2.9.1.tgz",
+      "integrity": "sha512-rUeTjXVisc9lhQ/rduBy/54dEJ/B+oZj43dvyNbyLd68p43zvIGqfDtsncCMjDnwvAzgkqQnmyBxaEQiEVepAQ==",
       "license": "MIT",
       "dependencies": {
-        "@portabletext/block-tools": "^3.5.1",
+        "@portabletext/block-tools": "^3.5.5",
         "@portabletext/keyboard-shortcuts": "^1.1.1",
         "@portabletext/patches": "^1.1.8",
         "@portabletext/schema": "^1.2.0",
@@ -3881,22 +3909,22 @@
         "@xstate/react": "^6.0.0",
         "debug": "^4.4.1",
         "get-random-values-esm": "^1.0.2",
-        "immer": "^10.1.1",
+        "immer": "^10.1.3",
         "lodash": "^4.17.21",
         "lodash.startcase": "^4.4.0",
-        "react-compiler-runtime": "19.1.0-rc.2",
+        "react-compiler-runtime": "19.1.0-rc.3",
         "slate": "0.118.1",
         "slate-dom": "^0.118.1",
         "slate-react": "0.117.4",
-        "xstate": "^5.20.2"
+        "xstate": "^5.21.0"
       },
       "engines": {
         "node": ">=20.19 <22 || >=22.12"
       },
       "peerDependencies": {
-        "@portabletext/sanity-bridge": "^1.1.7",
-        "@sanity/schema": "^4.6.0",
-        "@sanity/types": "^4.6.0",
+        "@portabletext/sanity-bridge": "^1.1.9",
+        "@sanity/schema": "^4.8.1",
+        "@sanity/types": "^4.8.1",
         "react": "^18.3 || ^19",
         "rxjs": "^7.8.2"
       }
@@ -3918,12 +3946,12 @@
       }
     },
     "node_modules/@portabletext/react": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@portabletext/react/-/react-4.0.2.tgz",
-      "integrity": "sha512-IuBAqJspmH7WNbUZanTHY49tREVqEtwaPPfoUWmBTva8Ywm3S/gy2IEbZu3mSQKlWDM4DQPAT9/Bqp3GkZegSg==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@portabletext/react/-/react-4.0.3.tgz",
+      "integrity": "sha512-sdVSXbi0L5MBVb1Ch5KwbBPZjW/Oqe6s5ZkPi4LcItzHl8rqY2jB0VxsFaGywZyn8Jc47cGLaOtyBM9HkW/9Hg==",
       "license": "MIT",
       "dependencies": {
-        "@portabletext/toolkit": "^3.0.0",
+        "@portabletext/toolkit": "^3.0.1",
         "@portabletext/types": "^2.0.15"
       },
       "engines": {
@@ -3934,9 +3962,9 @@
       }
     },
     "node_modules/@portabletext/sanity-bridge": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/@portabletext/sanity-bridge/-/sanity-bridge-1.1.7.tgz",
-      "integrity": "sha512-PqLukUrt3rOcGdKhK1Mv1KSjGk692OflPCF4q5mU3st1/4hMml0jxVxIZHRtf+W8FnxHo4pnhOFj9xBEywORMQ==",
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@portabletext/sanity-bridge/-/sanity-bridge-1.1.9.tgz",
+      "integrity": "sha512-Poe9zDU1F6IQQZ/WlznQM1Y2r+QrztSJpezoLYc7T7pAPvDl1PLGGk1PJpyXeUNWWY//0CC8x1ORnXEWKO1DNQ==",
       "license": "MIT",
       "dependencies": {
         "@portabletext/schema": "^1.2.0",
@@ -3947,8 +3975,8 @@
         "node": ">=20.19 <22 || >=22.12"
       },
       "peerDependencies": {
-        "@sanity/schema": "^4.6.0",
-        "@sanity/types": "^4.6.0"
+        "@sanity/schema": "^4.8.1",
+        "@sanity/types": "^4.8.1"
       }
     },
     "node_modules/@portabletext/schema": {
@@ -3971,12 +3999,12 @@
       }
     },
     "node_modules/@portabletext/toolkit": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@portabletext/toolkit/-/toolkit-3.0.0.tgz",
-      "integrity": "sha512-50otiRkac8unAAU+U9VdhpkZ4FqTG64kzz/6ckeBigKG/cGSU8YZLfmvDhdMH8tw+/uTI7d9Skwqm8RnTHZwDw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@portabletext/toolkit/-/toolkit-3.0.1.tgz",
+      "integrity": "sha512-z8NGqxKxfP0zuC58hPe8+xFC17qSbQ3nC9DgZmhrr7NUFaENJ6vAHJBsH5QzT7nKUjj++dTn+i4O2Uz9cqiGjA==",
       "license": "MIT",
       "dependencies": {
-        "@portabletext/types": "^2.0.13"
+        "@portabletext/types": "^2.0.15"
       },
       "engines": {
         "node": "^14.13.1 || >=16.0.0"
@@ -4021,9 +4049,9 @@
       "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.49.0.tgz",
-      "integrity": "sha512-rlKIeL854Ed0e09QGYFlmDNbka6I3EQFw7iZuugQjMb11KMpJCLPFL4ZPbMfaEhLADEL1yx0oujGkBQ7+qW3eA==",
+      "version": "4.50.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.50.1.tgz",
+      "integrity": "sha512-HJXwzoZN4eYTdD8bVV22DN8gsPCAj3V20NHKOs8ezfXanGpmVPR7kalUHd+Y31IJp9stdB87VKPFbsGY3H/2ag==",
       "cpu": [
         "arm"
       ],
@@ -4034,9 +4062,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.49.0.tgz",
-      "integrity": "sha512-cqPpZdKUSQYRtLLr6R4X3sD4jCBO1zUmeo3qrWBCqYIeH8Q3KRL4F3V7XJ2Rm8/RJOQBZuqzQGWPjjvFUcYa/w==",
+      "version": "4.50.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.50.1.tgz",
+      "integrity": "sha512-PZlsJVcjHfcH53mOImyt3bc97Ep3FJDXRpk9sMdGX0qgLmY0EIWxCag6EigerGhLVuL8lDVYNnSo8qnTElO4xw==",
       "cpu": [
         "arm64"
       ],
@@ -4047,9 +4075,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.49.0.tgz",
-      "integrity": "sha512-99kMMSMQT7got6iYX3yyIiJfFndpojBmkHfTc1rIje8VbjhmqBXE+nb7ZZP3A5skLyujvT0eIUCUsxAe6NjWbw==",
+      "version": "4.50.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.50.1.tgz",
+      "integrity": "sha512-xc6i2AuWh++oGi4ylOFPmzJOEeAa2lJeGUGb4MudOtgfyyjr4UPNK+eEWTPLvmPJIY/pgw6ssFIox23SyrkkJw==",
       "cpu": [
         "arm64"
       ],
@@ -4060,9 +4088,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.49.0.tgz",
-      "integrity": "sha512-y8cXoD3wdWUDpjOLMKLx6l+NFz3NlkWKcBCBfttUn+VGSfgsQ5o/yDUGtzE9HvsodkP0+16N0P4Ty1VuhtRUGg==",
+      "version": "4.50.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.50.1.tgz",
+      "integrity": "sha512-2ofU89lEpDYhdLAbRdeyz/kX3Y2lpYc6ShRnDjY35bZhd2ipuDMDi6ZTQ9NIag94K28nFMofdnKeHR7BT0CATw==",
       "cpu": [
         "x64"
       ],
@@ -4073,9 +4101,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.49.0.tgz",
-      "integrity": "sha512-3mY5Pr7qv4GS4ZvWoSP8zha8YoiqrU+e0ViPvB549jvliBbdNLrg2ywPGkgLC3cmvN8ya3za+Q2xVyT6z+vZqA==",
+      "version": "4.50.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.50.1.tgz",
+      "integrity": "sha512-wOsE6H2u6PxsHY/BeFHA4VGQN3KUJFZp7QJBmDYI983fgxq5Th8FDkVuERb2l9vDMs1D5XhOrhBrnqcEY6l8ZA==",
       "cpu": [
         "arm64"
       ],
@@ -4086,9 +4114,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.49.0.tgz",
-      "integrity": "sha512-C9KzzOAQU5gU4kG8DTk+tjdKjpWhVWd5uVkinCwwFub2m7cDYLOdtXoMrExfeBmeRy9kBQMkiyJ+HULyF1yj9w==",
+      "version": "4.50.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.50.1.tgz",
+      "integrity": "sha512-A/xeqaHTlKbQggxCqispFAcNjycpUEHP52mwMQZUNqDUJFFYtPHCXS1VAG29uMlDzIVr+i00tSFWFLivMcoIBQ==",
       "cpu": [
         "x64"
       ],
@@ -4099,9 +4127,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.49.0.tgz",
-      "integrity": "sha512-OVSQgEZDVLnTbMq5NBs6xkmz3AADByCWI4RdKSFNlDsYXdFtlxS59J+w+LippJe8KcmeSSM3ba+GlsM9+WwC1w==",
+      "version": "4.50.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.50.1.tgz",
+      "integrity": "sha512-54v4okehwl5TaSIkpp97rAHGp7t3ghinRd/vyC1iXqXMfjYUTm7TfYmCzXDoHUPTTf36L8pr0E7YsD3CfB3ZDg==",
       "cpu": [
         "arm"
       ],
@@ -4112,9 +4140,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.49.0.tgz",
-      "integrity": "sha512-ZnfSFA7fDUHNa4P3VwAcfaBLakCbYaxCk0jUnS3dTou9P95kwoOLAMlT3WmEJDBCSrOEFFV0Y1HXiwfLYJuLlA==",
+      "version": "4.50.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.50.1.tgz",
+      "integrity": "sha512-p/LaFyajPN/0PUHjv8TNyxLiA7RwmDoVY3flXHPSzqrGcIp/c2FjwPPP5++u87DGHtw+5kSH5bCJz0mvXngYxw==",
       "cpu": [
         "arm"
       ],
@@ -4125,9 +4153,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.49.0.tgz",
-      "integrity": "sha512-Z81u+gfrobVK2iV7GqZCBfEB1y6+I61AH466lNK+xy1jfqFLiQ9Qv716WUM5fxFrYxwC7ziVdZRU9qvGHkYIJg==",
+      "version": "4.50.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.50.1.tgz",
+      "integrity": "sha512-2AbMhFFkTo6Ptna1zO7kAXXDLi7H9fGTbVaIq2AAYO7yzcAsuTNWPHhb2aTA6GPiP+JXh85Y8CiS54iZoj4opw==",
       "cpu": [
         "arm64"
       ],
@@ -4138,9 +4166,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.49.0.tgz",
-      "integrity": "sha512-zoAwS0KCXSnTp9NH/h9aamBAIve0DXeYpll85shf9NJ0URjSTzzS+Z9evmolN+ICfD3v8skKUPyk2PO0uGdFqg==",
+      "version": "4.50.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.50.1.tgz",
+      "integrity": "sha512-Cgef+5aZwuvesQNw9eX7g19FfKX5/pQRIyhoXLCiBOrWopjo7ycfB292TX9MDcDijiuIJlx1IzJz3IoCPfqs9w==",
       "cpu": [
         "arm64"
       ],
@@ -4151,9 +4179,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.49.0.tgz",
-      "integrity": "sha512-2QyUyQQ1ZtwZGiq0nvODL+vLJBtciItC3/5cYN8ncDQcv5avrt2MbKt1XU/vFAJlLta5KujqyHdYtdag4YEjYQ==",
+      "version": "4.50.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.50.1.tgz",
+      "integrity": "sha512-RPhTwWMzpYYrHrJAS7CmpdtHNKtt2Ueo+BlLBjfZEhYBhK00OsEqM08/7f+eohiF6poe0YRDDd8nAvwtE/Y62Q==",
       "cpu": [
         "loong64"
       ],
@@ -4164,9 +4192,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.49.0.tgz",
-      "integrity": "sha512-k9aEmOWt+mrMuD3skjVJSSxHckJp+SiFzFG+v8JLXbc/xi9hv2icSkR3U7uQzqy+/QbbYY7iNB9eDTwrELo14g==",
+      "version": "4.50.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.50.1.tgz",
+      "integrity": "sha512-eSGMVQw9iekut62O7eBdbiccRguuDgiPMsw++BVUg+1K7WjZXHOg/YOT9SWMzPZA+w98G+Fa1VqJgHZOHHnY0Q==",
       "cpu": [
         "ppc64"
       ],
@@ -4177,9 +4205,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.49.0.tgz",
-      "integrity": "sha512-rDKRFFIWJ/zJn6uk2IdYLc09Z7zkE5IFIOWqpuU0o6ZpHcdniAyWkwSUWE/Z25N/wNDmFHHMzin84qW7Wzkjsw==",
+      "version": "4.50.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.50.1.tgz",
+      "integrity": "sha512-S208ojx8a4ciIPrLgazF6AgdcNJzQE4+S9rsmOmDJkusvctii+ZvEuIC4v/xFqzbuP8yDjn73oBlNDgF6YGSXQ==",
       "cpu": [
         "riscv64"
       ],
@@ -4190,9 +4218,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.49.0.tgz",
-      "integrity": "sha512-FkkhIY/hYFVnOzz1WeV3S9Bd1h0hda/gRqvZCMpHWDHdiIHn6pqsY3b5eSbvGccWHMQ1uUzgZTKS4oGpykf8Tw==",
+      "version": "4.50.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.50.1.tgz",
+      "integrity": "sha512-3Ag8Ls1ggqkGUvSZWYcdgFwriy2lWo+0QlYgEFra/5JGtAd6C5Hw59oojx1DeqcA2Wds2ayRgvJ4qxVTzCHgzg==",
       "cpu": [
         "riscv64"
       ],
@@ -4203,9 +4231,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.49.0.tgz",
-      "integrity": "sha512-gRf5c+A7QiOG3UwLyOOtyJMD31JJhMjBvpfhAitPAoqZFcOeK3Kc1Veg1z/trmt+2P6F/biT02fU19GGTS529A==",
+      "version": "4.50.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.50.1.tgz",
+      "integrity": "sha512-t9YrKfaxCYe7l7ldFERE1BRg/4TATxIg+YieHQ966jwvo7ddHJxPj9cNFWLAzhkVsbBvNA4qTbPVNsZKBO4NSg==",
       "cpu": [
         "s390x"
       ],
@@ -4216,9 +4244,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.49.0.tgz",
-      "integrity": "sha512-BR7+blScdLW1h/2hB/2oXM+dhTmpW3rQt1DeSiCP9mc2NMMkqVgjIN3DDsNpKmezffGC9R8XKVOLmBkRUcK/sA==",
+      "version": "4.50.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.50.1.tgz",
+      "integrity": "sha512-MCgtFB2+SVNuQmmjHf+wfI4CMxy3Tk8XjA5Z//A0AKD7QXUYFMQcns91K6dEHBvZPCnhJSyDWLApk40Iq/H3tA==",
       "cpu": [
         "x64"
       ],
@@ -4229,9 +4257,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.49.0.tgz",
-      "integrity": "sha512-hDMOAe+6nX3V5ei1I7Au3wcr9h3ktKzDvF2ne5ovX8RZiAHEtX1A5SNNk4zt1Qt77CmnbqT+upb/umzoPMWiPg==",
+      "version": "4.50.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.50.1.tgz",
+      "integrity": "sha512-nEvqG+0jeRmqaUMuwzlfMKwcIVffy/9KGbAGyoa26iu6eSngAYQ512bMXuqqPrlTyfqdlB9FVINs93j534UJrg==",
       "cpu": [
         "x64"
       ],
@@ -4241,10 +4269,23 @@
         "linux"
       ]
     },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.50.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.50.1.tgz",
+      "integrity": "sha512-RDsLm+phmT3MJd9SNxA9MNuEAO/J2fhW8GXk62G/B4G7sLVumNFbRwDL6v5NrESb48k+QMqdGbHgEtfU0LCpbA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.49.0.tgz",
-      "integrity": "sha512-wkNRzfiIGaElC9kXUT+HLx17z7D0jl+9tGYRKwd8r7cUqTL7GYAvgUY++U2hK6Ar7z5Z6IRRoWC8kQxpmM7TDA==",
+      "version": "4.50.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.50.1.tgz",
+      "integrity": "sha512-hpZB/TImk2FlAFAIsoElM3tLzq57uxnGYwplg6WDyAxbYczSi8O2eQ+H2Lx74504rwKtZ3N2g4bCUkiamzS6TQ==",
       "cpu": [
         "arm64"
       ],
@@ -4255,9 +4296,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.49.0.tgz",
-      "integrity": "sha512-gq5aW/SyNpjp71AAzroH37DtINDcX1Qw2iv9Chyz49ZgdOP3NV8QCyKZUrGsYX9Yyggj5soFiRCgsL3HwD8TdA==",
+      "version": "4.50.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.50.1.tgz",
+      "integrity": "sha512-SXjv8JlbzKM0fTJidX4eVsH+Wmnp0/WcD8gJxIZyR6Gay5Qcsmdbi9zVtnbkGPG8v2vMR1AD06lGWy5FLMcG7A==",
       "cpu": [
         "ia32"
       ],
@@ -4268,9 +4309,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.49.0.tgz",
-      "integrity": "sha512-gEtqFbzmZLFk2xKh7g0Rlo8xzho8KrEFEkzvHbfUGkrgXOpZ4XagQ6n+wIZFNh1nTb8UD16J4nFSFKXYgnbdBg==",
+      "version": "4.50.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.50.1.tgz",
+      "integrity": "sha512-StxAO/8ts62KZVRAm4JZYq9+NqNsV7RvimNK+YM7ry//zebEH6meuugqW/P5OFUCjyQgui+9fUxT6d5NShvMvA==",
       "cpu": [
         "x64"
       ],
@@ -4299,30 +4340,36 @@
         "rxjs": "^7.0.0"
       }
     },
+    "node_modules/@sanity/blueprints-parser": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@sanity/blueprints-parser/-/blueprints-parser-0.2.1.tgz",
+      "integrity": "sha512-oOyUNgIGkYbQcSBa/UniwYQoqf/DLpM9OGqGq8xfn6SY1ksnEtfjt/QaeeAn9Rl1BEUGQKSCat92Nhfu0VDSnA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19 <22 || >=22.12"
+      }
+    },
     "node_modules/@sanity/cli": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/@sanity/cli/-/cli-4.6.0.tgz",
-      "integrity": "sha512-Wrqlst5m1WmdFWOHpltUXjuXdYPSWMLn/0zChdVqDoL7LZkGBq0lccAFiPhfI4KRlNpt9E4pVTMH9T16Cdw+eg==",
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/@sanity/cli/-/cli-4.8.1.tgz",
+      "integrity": "sha512-bS7mn/GDmidgdo+kL+7xSztiam/qxDEdZ5XVwQS1SBMOaXfgOqbJOFZVya7JaZaxiSnu5FgI15Pdxqn/8jzgqQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.28.3",
-        "@sanity/client": "^7.9.0",
-        "@sanity/codegen": "4.6.0",
-        "@sanity/runtime-cli": "^10.3.1",
+        "@babel/traverse": "^7.28.4",
+        "@sanity/client": "^7.11.1",
+        "@sanity/codegen": "4.8.1",
+        "@sanity/runtime-cli": "^10.5.1",
         "@sanity/telemetry": "^0.8.0",
         "@sanity/template-validator": "^2.4.3",
-        "@sanity/util": "4.6.0",
         "chalk": "^4.1.2",
         "debug": "^4.4.1",
-        "decompress": "^4.2.1",
         "esbuild": "0.25.9",
         "esbuild-register": "^3.6.0",
         "get-it": "^8.6.10",
-        "groq-js": "^1.17.3",
+        "groq-js": "^1.18.0",
         "pkg-dir": "^5.0.0",
         "prettier": "^3.5.3",
-        "semver": "^7.7.2",
-        "validate-npm-package-name": "^3.0.0"
+        "semver": "^7.7.2"
       },
       "bin": {
         "sanity": "bin/sanity"
@@ -4344,9 +4391,9 @@
       }
     },
     "node_modules/@sanity/client": {
-      "version": "7.10.0",
-      "resolved": "https://registry.npmjs.org/@sanity/client/-/client-7.10.0.tgz",
-      "integrity": "sha512-3UV6pJupue7UAZh4g5n0lYjuRsIb4c6IoqMywVLMHYoSOeHJfgSzbexOPGMNqvF+KUywUA0GyFi9cAVeMKofvw==",
+      "version": "7.11.1",
+      "resolved": "https://registry.npmjs.org/@sanity/client/-/client-7.11.1.tgz",
+      "integrity": "sha512-nvuyItcknj2qFH3FPqqZhjN94rHv7eRzuHveN2ZIhHTGhGYLp1zE7UfESMcNn+flL/Oik+Ctkp3jKB3z02NdHQ==",
       "license": "MIT",
       "dependencies": {
         "@sanity/eventsource": "^5.0.2",
@@ -4359,23 +4406,23 @@
       }
     },
     "node_modules/@sanity/codegen": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/@sanity/codegen/-/codegen-4.6.0.tgz",
-      "integrity": "sha512-Ott9PEw/uDF4G9EDMMogv/8TAQbbgTbxgsFLL9Q7cXQUOxubAs27C7DehCVVKpTcoB2v8gWv2Na5Cvi5Jp63Tg==",
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/@sanity/codegen/-/codegen-4.8.1.tgz",
+      "integrity": "sha512-Hld3LM+ExBK2ioH4oKPkAJP89+KOVuBREcaxat44kMR2oJw7YcA+tQi/qX4ey6G9IJdltzZLrat5aJj1gXW7Dw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/core": "^7.28.3",
+        "@babel/core": "^7.28.4",
         "@babel/generator": "^7.28.3",
         "@babel/preset-env": "^7.28.3",
         "@babel/preset-react": "^7.27.1",
         "@babel/preset-typescript": "^7.27.1",
         "@babel/register": "^7.28.3",
-        "@babel/traverse": "^7.28.3",
-        "@babel/types": "^7.28.2",
+        "@babel/traverse": "^7.28.4",
+        "@babel/types": "^7.28.4",
         "debug": "^4.4.1",
         "globby": "^11.1.0",
-        "groq": "4.6.0",
-        "groq-js": "^1.17.3",
+        "groq": "4.8.1",
+        "groq-js": "^1.18.0",
         "json5": "^2.2.3",
         "tsconfig-paths": "^4.2.0",
         "zod": "^3.25.76"
@@ -4433,9 +4480,9 @@
       }
     },
     "node_modules/@sanity/diff": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/@sanity/diff/-/diff-4.6.0.tgz",
-      "integrity": "sha512-K8lYLqx4w+K3I2LHX2ik4nkoruKPIdTjxibujdtGFuO9TpaqI20aPmDmCkBK0JLMPjVvmbtWCV2Ys3QARkc67Q==",
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/@sanity/diff/-/diff-4.8.1.tgz",
+      "integrity": "sha512-p6rBKcUShlXeriiOf4VxfH3W7x3cb0xc6WcDJ9s2vVAlgvdhdPaNkWlqAtJgI/7QSguK4nVVqav+lItlyWr1fQ==",
       "license": "MIT",
       "dependencies": {
         "@sanity/diff-match-patch": "^3.2.0"
@@ -4826,24 +4873,24 @@
       }
     },
     "node_modules/@sanity/insert-menu": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@sanity/insert-menu/-/insert-menu-2.0.1.tgz",
-      "integrity": "sha512-PBHua3RJ+YAH71YJwDgh31XROoytl28jipaJk3H2i9Btt0GwzpyaCKaqRTNWsf4k+dQ4HMFw1URrtt4WCCQTPw==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@sanity/insert-menu/-/insert-menu-2.0.2.tgz",
+      "integrity": "sha512-ltR9DNOIAQRbwuch68U3f4YM+7rTqI5WAkMle/T/VBLe3peYeqL9QyOLthynR3gfZLZR8jFU8nryH5c2xZmOxg==",
       "license": "MIT",
       "dependencies": {
         "@sanity/icons": "^3.7.4",
         "@sanity/ui": "^3.0.0",
         "lodash": "^4.17.21",
-        "react-compiler-runtime": "19.1.0-rc.2"
+        "react-compiler-runtime": "19.1.0-rc.3"
       },
       "engines": {
         "node": ">=20.19"
       },
       "peerDependencies": {
         "@sanity/types": "*",
-        "react": "^18.3 || >=19.0.0-rc",
-        "react-dom": "^18.3 || >=19.0.0-rc",
-        "react-is": "^18.3 || >=19.0.0-rc"
+        "react": "^18.3 || ^19",
+        "react-dom": "^18.3 || ^19",
+        "react-is": "^18.3 || ^19"
       }
     },
     "node_modules/@sanity/json-match": {
@@ -4889,23 +4936,60 @@
       }
     },
     "node_modules/@sanity/migrate": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/@sanity/migrate/-/migrate-4.6.0.tgz",
-      "integrity": "sha512-6OKhc3oml+fOoGFpCR3hNJ9nSpLFcxdca+ohUbGbML5ku1Jl6/ElcVVw2UEoQI500xZZVWL0RzJBBbvzgB5i3w==",
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/@sanity/migrate/-/migrate-4.8.1.tgz",
+      "integrity": "sha512-vEEvBwdY/qZNNZUNiPUjyxH8/7jYQozi3t7Wru9XeeZwZ99dtDnXrv3crUcxUwFTmN++FJibJoK/u+gC4zp5Jw==",
       "license": "MIT",
       "dependencies": {
-        "@sanity/client": "^7.9.0",
-        "@sanity/mutate": "^0.12.4",
-        "@sanity/types": "4.6.0",
-        "@sanity/util": "4.6.0",
+        "@sanity/client": "^7.11.1",
+        "@sanity/mutate": "^0.13.0",
+        "@sanity/types": "4.8.1",
+        "@sanity/util": "4.8.1",
         "arrify": "^2.0.1",
         "debug": "^4.4.1",
         "fast-fifo": "^1.3.2",
-        "groq-js": "^1.17.3",
+        "groq-js": "^1.18.0",
         "p-map": "^7.0.1"
       },
       "engines": {
         "node": ">=20.19 <22 || >=22.12"
+      }
+    },
+    "node_modules/@sanity/migrate/node_modules/@sanity/mutate": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@sanity/mutate/-/mutate-0.13.0.tgz",
+      "integrity": "sha512-UR+JTkH3z+0cV/PI3p9YXT4IaVl5qGDPn+E33B6A42HpOGwbI92XAKu1m1V7DVQ3iB9VtX1khgStAy9sAS9rsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sanity/client": "^7.9.0",
+        "@sanity/diff-match-patch": "^3.2.0",
+        "@sanity/uuid": "^3.0.2",
+        "hotscript": "^1.0.13",
+        "lodash": "^4.17.21",
+        "mendoza": "^3.0.8",
+        "nanoid": "^5.1.3",
+        "rxjs": "^7.8.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sanity/migrate/node_modules/nanoid": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.5.tgz",
+      "integrity": "sha512-Ir/+ZpE9fDsNH0hQ3C68uyThDXzYcim2EqcZ8zn8Chtt1iylPT9xXJB0kPCnqzgcEGikO9RxSrh63MsmVCU7Fw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
       }
     },
     "node_modules/@sanity/mutate": {
@@ -4946,26 +5030,26 @@
       }
     },
     "node_modules/@sanity/mutator": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/@sanity/mutator/-/mutator-4.6.0.tgz",
-      "integrity": "sha512-rPR9y/Of9A7xqXxN8F8WaikABPcGftFQYvVtC+BV4kDtuS6cQc+0e0CoKpJ9Wjp/CL2x0nuy3bwdFwy7huDiuw==",
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/@sanity/mutator/-/mutator-4.8.1.tgz",
+      "integrity": "sha512-0p/vdk1T1ap8ILW7z/VBnhtZPftQKKKSrUfviT5obxI3KAVOUJC5y58Ie8WUGkwKN5EQbKb+H80cMO0vvm/CTA==",
       "license": "MIT",
       "dependencies": {
         "@sanity/diff-match-patch": "^3.2.0",
-        "@sanity/types": "4.6.0",
+        "@sanity/types": "4.8.1",
         "@sanity/uuid": "^3.0.2",
         "debug": "^4.4.1",
         "lodash": "^4.17.21"
       }
     },
     "node_modules/@sanity/presentation-comlink": {
-      "version": "1.0.28",
-      "resolved": "https://registry.npmjs.org/@sanity/presentation-comlink/-/presentation-comlink-1.0.28.tgz",
-      "integrity": "sha512-3LqQQ9MZy4Vut65XYsW0mPFF3gdv/8OKQy3m7zuSIc1HkQNbSLqbD+o7KaBfDnpXQxfk6HXS2zJyrJRO87us1A==",
+      "version": "1.0.29",
+      "resolved": "https://registry.npmjs.org/@sanity/presentation-comlink/-/presentation-comlink-1.0.29.tgz",
+      "integrity": "sha512-IPXRqlgDEmuGMfgeovyQqgVt9X49OlZs8gOdeKM7lSj/KIBzx/X+m6MtnDdUOZpYLqROF2mIbYTmyyo3PsNmkg==",
       "license": "MIT",
       "dependencies": {
         "@sanity/comlink": "^3.0.9",
-        "@sanity/visual-editing-types": "^1.1.5"
+        "@sanity/visual-editing-types": "^1.1.6"
       },
       "engines": {
         "node": ">=18"
@@ -4975,9 +5059,9 @@
       }
     },
     "node_modules/@sanity/preview-url-secret": {
-      "version": "2.1.14",
-      "resolved": "https://registry.npmjs.org/@sanity/preview-url-secret/-/preview-url-secret-2.1.14.tgz",
-      "integrity": "sha512-wjk/M0/1Ah4Kg2N4NXySvrZCI3bROTONMA5mOzeYFjnh8Ib1fMI215VJk3/hPF3PzmfRf9mt6Od3Y5N9vYRt6g==",
+      "version": "2.1.15",
+      "resolved": "https://registry.npmjs.org/@sanity/preview-url-secret/-/preview-url-secret-2.1.15.tgz",
+      "integrity": "sha512-pHDZ6G1XeCco7wmlGNFeA5nOdtXK05imtEtUFHEIE/isZEFXL4V2AL2OGc/ktV9hWr7D9+w1kAI6PfE/SwXNVg==",
       "license": "MIT",
       "dependencies": {
         "@sanity/uuid": "3.0.2"
@@ -4986,19 +5070,30 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "@sanity/client": "^7.8.0"
+        "@sanity/client": "^7.8.2",
+        "@sanity/icons": "*",
+        "sanity": "*"
+      },
+      "peerDependenciesMeta": {
+        "@sanity/icons": {
+          "optional": true
+        },
+        "sanity": {
+          "optional": true
+        }
       }
     },
     "node_modules/@sanity/runtime-cli": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@sanity/runtime-cli/-/runtime-cli-10.4.1.tgz",
-      "integrity": "sha512-BdXQca17+q7H4m6+xm0BakIKuTgnVSRP2mHAuVjCXljMLJLTXvbtxz0lNtmFIGU7haedEjY/yTolwjiMZL9SrQ==",
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/@sanity/runtime-cli/-/runtime-cli-10.7.0.tgz",
+      "integrity": "sha512-10FPgIGm/0keRghBh3lwmek1QPK/G1XxawmxEmaqc6ieAEsGSSFaOWu2uyWneJEd3CAMjoIuZ8zjjZ4EjWsJng==",
       "license": "MIT",
       "dependencies": {
         "@architect/hydrate": "^4.0.8",
         "@architect/inventory": "^4.0.9",
         "@oclif/core": "^4.5.2",
         "@oclif/plugin-help": "^6.2.32",
+        "@sanity/blueprints-parser": "^0.2.1",
         "@sanity/client": "^7.8.2",
         "adm-zip": "^0.5.16",
         "array-treeify": "^0.1.5",
@@ -5007,7 +5102,7 @@
         "eventsource": "^4.0.0",
         "find-up": "^7.0.0",
         "get-folder-size": "^5.0.0",
-        "groq-js": "^1.17.3",
+        "groq-js": "^1.18.0",
         "inquirer": "^12.9.2",
         "jiti": "^2.5.1",
         "mime-types": "^3.0.1",
@@ -5026,9 +5121,9 @@
       }
     },
     "node_modules/@sanity/runtime-cli/node_modules/chalk": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.0.tgz",
-      "integrity": "sha512-46QrSQFyVSEyYAgQ22hQ+zDa60YHA4fBstHmtSApj1Y5vKtG27fWowW03jCk5KcbXEWPZUIR894aARCA/G1kfQ==",
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
       "license": "MIT",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
@@ -5276,29 +5371,17 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@sanity/runtime-cli/node_modules/yocto-queue": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.1.tgz",
-      "integrity": "sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@sanity/schema": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/@sanity/schema/-/schema-4.6.0.tgz",
-      "integrity": "sha512-EkCMecou56j9DfvbAqCuwTHy6nszuLkmDYXxMHELgfNbopxWZzQU/KdvP54RVn/iVwOTlYykgFns90l/oicpug==",
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/@sanity/schema/-/schema-4.8.1.tgz",
+      "integrity": "sha512-EzGCHb5IQ8U0vOTeqd29uZSA2dc43Bshj+TPcnkfXqQdCfq4ti9EHITwo6IBdQJRxuvU6hBKXa3WGbHrN+rfkw==",
       "license": "MIT",
       "dependencies": {
         "@sanity/descriptors": "^1.1.1",
         "@sanity/generate-help-url": "^3.0.0",
-        "@sanity/types": "4.6.0",
+        "@sanity/types": "4.8.1",
         "arrify": "^2.0.1",
-        "groq-js": "^1.17.3",
+        "groq-js": "^1.18.0",
         "humanize-list": "^1.0.1",
         "leven": "^3.1.0",
         "lodash": "^4.17.21",
@@ -5439,12 +5522,12 @@
       }
     },
     "node_modules/@sanity/types": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/@sanity/types/-/types-4.6.0.tgz",
-      "integrity": "sha512-Mn4z2izu+Sg1mquPQzS8dFCVeao3a3fCM/qfgOlm8PU8IM6vaXpF65KePf4QRuq1HXJ8OmQFAIImuxzOMyGqzw==",
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/@sanity/types/-/types-4.8.1.tgz",
+      "integrity": "sha512-L+BQS0Hngn3R+uuW3dRfIInBZvwCrgKD7ifDE6kZeG9j1+Mm5mjfIKV084j0htVAmmew1BURZGLS8/p2YwE41Q==",
       "license": "MIT",
       "dependencies": {
-        "@sanity/client": "^7.9.0",
+        "@sanity/client": "^7.11.1",
         "@sanity/media-library-types": "^1.0.0"
       },
       "peerDependencies": {
@@ -5452,9 +5535,9 @@
       }
     },
     "node_modules/@sanity/ui": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@sanity/ui/-/ui-3.0.8.tgz",
-      "integrity": "sha512-z8gG72THNWZ6kTFLSK8/owUwFyDRm7FU7vOK82aYumKks5qN2G1CfzIKbHNfg+cF7cIkWiQyvjPIbWnlMIpi+g==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@sanity/ui/-/ui-3.1.0.tgz",
+      "integrity": "sha512-RH/gr+XKqk2xdvIpDfwuFwrmmeeCJUoFT2/Unbg8bfgQz+KbHIsIDyn3SzbOoL2oAo648H2h6gm7aXQP1BjvXg==",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/react-dom": "^2.1.6",
@@ -5463,7 +5546,7 @@
         "@sanity/icons": "^3.7.4",
         "csstype": "^3.1.3",
         "framer-motion": "^12.23.12",
-        "react-compiler-runtime": "19.1.0-rc.2",
+        "react-compiler-runtime": "19.1.0-rc.3",
         "react-refractor": "^4.0.0",
         "use-effect-event": "^2.0.3"
       },
@@ -5478,15 +5561,15 @@
       }
     },
     "node_modules/@sanity/util": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/@sanity/util/-/util-4.6.0.tgz",
-      "integrity": "sha512-ie+5EhU8mRnFJYFy4xNQpanxexI39JTf1tnaKN2CD95FLTrBJEU4rzvEFafrvVceIxmUxZCtgrkZERKPMQ8j4w==",
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/@sanity/util/-/util-4.8.1.tgz",
+      "integrity": "sha512-fzWLS67vNCQdkcMjVsC/X0dR29rVQ6eE4/X7munXkkqjBx6B9fGnzPBb4b7IpIIRNH5CDyjWs8ltpZgDZoUtOA==",
       "license": "MIT",
       "dependencies": {
         "@date-fns/tz": "^1.4.1",
         "@date-fns/utc": "^2.1.1",
-        "@sanity/client": "^7.9.0",
-        "@sanity/types": "4.6.0",
+        "@sanity/client": "^7.11.1",
+        "@sanity/types": "4.8.1",
         "date-fns": "^4.1.0",
         "get-random-values-esm": "1.0.2",
         "rxjs": "^7.8.2"
@@ -5516,25 +5599,25 @@
       }
     },
     "node_modules/@sanity/vision": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/@sanity/vision/-/vision-4.6.0.tgz",
-      "integrity": "sha512-rek3mPbz/Va1hUnzYfOEk+GOvcQbFsVGHE8cM5YoG/3MlbDA/dRe0HkmiPiwdWwU1Ui7Hxo1doTkzrjCiRfZuA==",
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/@sanity/vision/-/vision-4.8.1.tgz",
+      "integrity": "sha512-lyfkTWB1T5Vwgn2xU3No0Eys1Qmy43u25s10NcJ7jwCqf/F29zeldvP4IG9pBY47cbB8ydCAEJmCb+AQWflccw==",
       "license": "MIT",
       "dependencies": {
-        "@codemirror/autocomplete": "^6.18.6",
+        "@codemirror/autocomplete": "^6.18.7",
         "@codemirror/commands": "^6.8.1",
         "@codemirror/lang-javascript": "^6.2.4",
         "@codemirror/language": "^6.11.3",
         "@codemirror/search": "^6.5.11",
         "@codemirror/state": "^6.5.2",
-        "@codemirror/view": "^6.38.1",
+        "@codemirror/view": "^6.38.2",
         "@juggle/resize-observer": "^3.4.0",
         "@lezer/highlight": "^1.2.1",
         "@rexxars/react-json-inspector": "^9.0.1",
         "@rexxars/react-split-pane": "^1.0.0",
         "@sanity/color": "^3.0.6",
         "@sanity/icons": "^3.7.4",
-        "@sanity/ui": "^3.0.7",
+        "@sanity/ui": "^3.0.14",
         "@sanity/uuid": "^3.0.2",
         "@uiw/react-codemirror": "^4.25.1",
         "is-hotkey-esm": "^1.0.0",
@@ -5542,9 +5625,9 @@
         "json5": "^2.2.3",
         "lodash": "^4.17.21",
         "quick-lru": "^5.1.1",
-        "react-compiler-runtime": "19.1.0-rc.2",
+        "react-compiler-runtime": "19.1.0-rc.3",
         "react-fast-compare": "^3.2.2",
-        "react-rx": "^4.1.31",
+        "react-rx": "^4.1.32",
         "rxjs": "^7.8.2",
         "use-effect-event": "^2.0.3"
       },
@@ -5554,15 +5637,15 @@
       }
     },
     "node_modules/@sanity/visual-editing-types": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@sanity/visual-editing-types/-/visual-editing-types-1.1.5.tgz",
-      "integrity": "sha512-jDQyO59R9TG7QC6XQ5n8PVWCVRdebez1ws9d8j1HVmPzjIhWRkyQbA/xrfrtYDPo/vuVD8wUbkXOh1TScITVXQ==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@sanity/visual-editing-types/-/visual-editing-types-1.1.6.tgz",
+      "integrity": "sha512-CJlbFdQa0PeMhdX6mzmnu1QAhojrd/vLpPaeOFlGNXwCEgQTEoK9nR4510SQqkX6skx0uvb0YICc8M0nWVCsbw==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
-        "@sanity/client": "^7.8.1",
+        "@sanity/client": "^7.8.2",
         "@sanity/types": "*"
       },
       "peerDependenciesMeta": {
@@ -6260,6 +6343,33 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@wordpress/block-serialization-default-parser": {
+      "version": "5.30.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/block-serialization-default-parser/-/block-serialization-default-parser-5.30.0.tgz",
+      "integrity": "sha512-7bCeSqlkzkisn4MsVpkpNM8OsM8Orkulkg2lL6TKH0bYnDGZLYFmz2Jv5PC2MfUf7g0F1lkXu078Rg11s8aQjQ==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "7.25.7"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/block-serialization-default-parser/node_modules/@babel/runtime": {
+      "version": "7.25.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
+      "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regenerator-runtime": "^0.14.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@xstate/react": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@xstate/react/-/react-6.0.0.tgz",
@@ -6699,6 +6809,7 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
       "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "possible-typed-array-names": "^1.0.0"
@@ -6960,22 +7071,6 @@
         "ieee754": "^1.1.13"
       }
     },
-    "node_modules/buffer-alloc": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
-      "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
-      "license": "MIT",
-      "dependencies": {
-        "buffer-alloc-unsafe": "^1.1.0",
-        "buffer-fill": "^1.0.0"
-      }
-    },
-    "node_modules/buffer-alloc-unsafe": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
-      "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
-      "license": "MIT"
-    },
     "node_modules/buffer-crc32": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
@@ -6985,28 +7080,17 @@
         "node": ">=8.0.0"
       }
     },
-    "node_modules/buffer-fill": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
-      "integrity": "sha512-T7zexNBwiiaCOGDg9xNX9PBmjrubblRkENuptryuI64URkXDFum9il/JGL8Lm8wYfAXpredVXXZz7eMHilimiQ==",
-      "license": "MIT"
-    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "license": "MIT"
     },
-    "node_modules/builtins": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz",
-      "integrity": "sha512-uYBjakWipfaO/bXI7E8rq6kpwHRZK5cNYrUv2OzZSI/FvmdMyXJ2tG9dKcjEC5YHmHpUAwsargWIZNWdxb/bnQ==",
-      "license": "MIT"
-    },
     "node_modules/call-bind": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
       "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.0",
@@ -7038,6 +7122,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -7424,12 +7509,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "license": "MIT"
-    },
     "node_modules/commondir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
@@ -7697,12 +7776,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/cssstyle/node_modules/rrweb-cssom": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
-      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
-      "license": "MIT"
-    },
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
@@ -7899,25 +7972,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/decompress": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/decompress/-/decompress-4.2.1.tgz",
-      "integrity": "sha512-e48kc2IjU+2Zw8cTb6VZcJQ3lgVbS4uuB1TfCHbiZIP/haNXm+SVyhu+87jts5/3ROpd82GSVCoNs/z8l4ZOaQ==",
-      "license": "MIT",
-      "dependencies": {
-        "decompress-tar": "^4.0.0",
-        "decompress-tarbz2": "^4.0.0",
-        "decompress-targz": "^4.0.0",
-        "decompress-unzip": "^4.0.1",
-        "graceful-fs": "^4.1.10",
-        "make-dir": "^1.0.0",
-        "pify": "^2.3.0",
-        "strip-dirs": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/decompress-response": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-7.0.0.tgz",
@@ -7931,195 +7985,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/decompress-tar": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-4.1.1.tgz",
-      "integrity": "sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ==",
-      "license": "MIT",
-      "dependencies": {
-        "file-type": "^5.2.0",
-        "is-stream": "^1.1.0",
-        "tar-stream": "^1.5.2"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/decompress-tar/node_modules/bl": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.3.tgz",
-      "integrity": "sha512-pvcNpa0UU69UT341rO6AYy4FVAIkUHuZXRIWbq+zHnsVcRzDDjIAhGuuYoi0d//cwIwtt4pkpKycWEfjdV+vww==",
-      "license": "MIT",
-      "dependencies": {
-        "readable-stream": "^2.3.5",
-        "safe-buffer": "^5.1.1"
-      }
-    },
-    "node_modules/decompress-tar/node_modules/is-stream": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/decompress-tar/node_modules/isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "license": "MIT"
-    },
-    "node_modules/decompress-tar/node_modules/readable-stream": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/decompress-tar/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "license": "MIT"
-    },
-    "node_modules/decompress-tar/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
-    "node_modules/decompress-tar/node_modules/tar-stream": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
-      "integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
-      "license": "MIT",
-      "dependencies": {
-        "bl": "^1.0.0",
-        "buffer-alloc": "^1.2.0",
-        "end-of-stream": "^1.0.0",
-        "fs-constants": "^1.0.0",
-        "readable-stream": "^2.3.0",
-        "to-buffer": "^1.1.1",
-        "xtend": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/decompress-tarbz2": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-4.1.1.tgz",
-      "integrity": "sha512-s88xLzf1r81ICXLAVQVzaN6ZmX4A6U4z2nMbOwobxkLoIIfjVMBg7TeguTUXkKeXni795B6y5rnvDw7rxhAq9A==",
-      "license": "MIT",
-      "dependencies": {
-        "decompress-tar": "^4.1.0",
-        "file-type": "^6.1.0",
-        "is-stream": "^1.1.0",
-        "seek-bzip": "^1.0.5",
-        "unbzip2-stream": "^1.0.9"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/decompress-tarbz2/node_modules/file-type": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-6.2.0.tgz",
-      "integrity": "sha512-YPcTBDV+2Tm0VqjybVd32MHdlEGAtuxS3VAYsumFokDSMG+ROT5wawGlnHDoz7bfMcMDt9hxuXvXwoKUx2fkOg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/decompress-tarbz2/node_modules/is-stream": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/decompress-targz": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/decompress-targz/-/decompress-targz-4.1.1.tgz",
-      "integrity": "sha512-4z81Znfr6chWnRDNfFNqLwPvm4db3WuZkqV+UgXQzSngG3CEKdBkw5jrv3axjjL96glyiiKjsxJG3X6WBZwX3w==",
-      "license": "MIT",
-      "dependencies": {
-        "decompress-tar": "^4.1.1",
-        "file-type": "^5.2.0",
-        "is-stream": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/decompress-targz/node_modules/is-stream": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/decompress-unzip": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/decompress-unzip/-/decompress-unzip-4.0.1.tgz",
-      "integrity": "sha512-1fqeluvxgnn86MOh66u8FjbtJpAFv5wgCT9Iw8rcBqQcCo5tO8eiJw7NNTrvt9n4CRBVq7CstiS922oPgyGLrw==",
-      "license": "MIT",
-      "dependencies": {
-        "file-type": "^3.8.0",
-        "get-stream": "^2.2.0",
-        "pify": "^2.3.0",
-        "yauzl": "^2.4.2"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/decompress-unzip/node_modules/file-type": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
-      "integrity": "sha512-RLoqTXE8/vPmMuTI88DAzhMYC99I8BWv7zYP4A1puo5HIjEJ5EX48ighy4ZyKMG9EDXxBgW6e++cn7d1xuFghA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/decompress/node_modules/make-dir": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
-      "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
-      "license": "MIT",
-      "dependencies": {
-        "pify": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/decompress/node_modules/make-dir/node_modules/pify": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-      "integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/deeks": {
@@ -8154,6 +8019,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
       "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0",
@@ -9086,15 +8952,6 @@
         "reusify": "^1.0.4"
       }
     },
-    "node_modules/fd-slicer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
-      "license": "MIT",
-      "dependencies": {
-        "pend": "~1.2.0"
-      }
-    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -9123,15 +8980,6 @@
       },
       "engines": {
         "node": ">=16.0.0"
-      }
-    },
-    "node_modules/file-type": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
-      "integrity": "sha512-Iq1nJ6D2+yIO4c8HHg4fyVb8mAJieo1Oloy1mLLaB2PvezNedhBVm+QU7g0qM42aiMbRXTxKKwGD17rjKNJYVQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/file-uri-to-path": {
@@ -9461,6 +9309,7 @@
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
       "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-callable": "^1.2.7"
@@ -9725,9 +9574,9 @@
       }
     },
     "node_modules/get-east-asian-width": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.3.1.tgz",
-      "integrity": "sha512-R1QfovbPsKmosqTnPoRFiJ7CF9MLRgb53ChvMZm+r4p76/+8yKDy17qLL2PKInORy2RkZZekuK0efYgmzTkXyQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.4.0.tgz",
+      "integrity": "sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -9830,19 +9679,6 @@
       "license": "MIT",
       "dependencies": {
         "get-random-values": "^1.2.2"
-      }
-    },
-    "node_modules/get-stream": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
-      "integrity": "sha512-AUGhbbemXxrZJRD5cDvKtQxLuYaIbNtDTK8YqupCI393Q2KSTreEsLUN3ZxAWFGiKTzL6nKuzfcIvieflUX9qA==",
-      "license": "MIT",
-      "dependencies": {
-        "object-assign": "^4.0.1",
-        "pinkie-promise": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/get-symbol-description": {
@@ -10077,18 +9913,18 @@
       "license": "MIT"
     },
     "node_modules/groq": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/groq/-/groq-4.6.0.tgz",
-      "integrity": "sha512-nQdkN9z5cCS51qOFk7wP+BpPgCOqVRpQF+U4hPezO5PrIA0HBIuPwwZayjnvP93CXsMnNJa0GnQn7/Xlam8DiQ==",
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/groq/-/groq-4.8.1.tgz",
+      "integrity": "sha512-H9Osf37VA6jkqZFmZdG/XAZ19quo+CcYo/qvFu3+rYgtSqS7j2QNgiW4xpXUzFvlXHI0cLEZVhy/tShytVcSoA==",
       "license": "MIT",
       "engines": {
         "node": ">=20.19 <22 || >=22.12"
       }
     },
     "node_modules/groq-js": {
-      "version": "1.17.3",
-      "resolved": "https://registry.npmjs.org/groq-js/-/groq-js-1.17.3.tgz",
-      "integrity": "sha512-Z6/n5Ro246RlntMoZKTIjB3GDCFcs8NLCkIrI8AbS1Ho7yVAtNQqxxJd2W4ENk9+a03gTQYtunNGlcHJM9hhQw==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/groq-js/-/groq-js-1.18.0.tgz",
+      "integrity": "sha512-24Tn7L9YrVeZxJVfAj5StrOVV1TJoOlY3oetLk/uo/BogWah8WBI7ChYGEidMXZ0gbU9Ydy3NhhO/fwisumcXg==",
       "license": "MIT",
       "dependencies": {
         "debug": "^4.3.4"
@@ -10195,6 +10031,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
       "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0"
@@ -10307,9 +10144,9 @@
       }
     },
     "node_modules/hls.js": {
-      "version": "1.6.11",
-      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.6.11.tgz",
-      "integrity": "sha512-tdDwOAgPGXohSiNE4oxGr3CI9Hx9lsGLFe6TULUvRk2TfHS+w1tSAJntrvxsHaxvjtr6BXsDZM7NOqJFhU4mmg==",
+      "version": "1.6.12",
+      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.6.12.tgz",
+      "integrity": "sha512-Pz+7IzvkbAht/zXvwLzA/stUHNqztqKvlLbfpq6ZYU68+gZ+CZMlsbQBPUviRap+3IQ41E39ke7Ia+yvhsehEQ==",
       "license": "Apache-2.0"
     },
     "node_modules/hoist-non-react-statics": {
@@ -10374,6 +10211,23 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/html-entities": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.6.0.tgz",
+      "integrity": "sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/mdevils"
+        },
+        {
+          "type": "patreon",
+          "url": "https://patreon.com/mdevils"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/html-parse-stringify": {
       "version": "3.0.1",
@@ -10481,9 +10335,9 @@
       }
     },
     "node_modules/immer": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-10.1.1.tgz",
-      "integrity": "sha512-s2MPrmjovJcoMaHtx6K11Ra7oD05NT97w1IC5zpMkT6Atjr7H8LjaDd81iIxUYpMKSRRNMJE703M1Fhr/TctHw==",
+      "version": "10.1.3",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.1.3.tgz",
+      "integrity": "sha512-tmjF/k8QDKydUlm3mZU+tjM6zeq9/fFpPqH9SzWmBnVVKsPBg/V66qsMwb3/Bo90cgUN+ghdVBess+hPsxUyRw==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -10688,6 +10542,7 @@
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
       "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -10895,12 +10750,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-natural-number": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-4.0.1.tgz",
-      "integrity": "sha512-Y4LTamMe0DDQIIAlaer9eKebAlDSV6huy+TWhJVPlzZh2o4tRP5SQWFlLn5N0To4mDD22/qdOq+veo1cSISLgQ==",
-      "license": "MIT"
-    },
     "node_modules/is-negative-zero": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
@@ -11096,6 +10945,7 @@
       "version": "1.1.15",
       "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
       "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "which-typed-array": "^1.1.16"
@@ -11187,6 +11037,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
       "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/isexe": {
@@ -11215,63 +11066,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/isomorphic-dompurify/node_modules/jsdom": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
-      "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
-      "license": "MIT",
-      "dependencies": {
-        "cssstyle": "^4.2.1",
-        "data-urls": "^5.0.0",
-        "decimal.js": "^10.5.0",
-        "html-encoding-sniffer": "^4.0.0",
-        "http-proxy-agent": "^7.0.2",
-        "https-proxy-agent": "^7.0.6",
-        "is-potential-custom-element-name": "^1.0.1",
-        "nwsapi": "^2.2.16",
-        "parse5": "^7.2.1",
-        "rrweb-cssom": "^0.8.0",
-        "saxes": "^6.0.0",
-        "symbol-tree": "^3.2.4",
-        "tough-cookie": "^5.1.1",
-        "w3c-xmlserializer": "^5.0.0",
-        "webidl-conversions": "^7.0.0",
-        "whatwg-encoding": "^3.1.1",
-        "whatwg-mimetype": "^4.0.0",
-        "whatwg-url": "^14.1.1",
-        "ws": "^8.18.0",
-        "xml-name-validator": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "canvas": "^3.0.0"
-      },
-      "peerDependenciesMeta": {
-        "canvas": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/isomorphic-dompurify/node_modules/rrweb-cssom": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
-      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
-      "license": "MIT"
-    },
-    "node_modules/isomorphic-dompurify/node_modules/tough-cookie": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
-      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "tldts": "^6.1.32"
-      },
-      "engines": {
-        "node": ">=16"
       }
     },
     "node_modules/iterator.prototype": {
@@ -11353,38 +11147,37 @@
       }
     },
     "node_modules/jsdom": {
-      "version": "23.2.0",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-23.2.0.tgz",
-      "integrity": "sha512-L88oL7D/8ufIES+Zjz7v0aes+oBMh2Xnh3ygWvL0OaICOomKEPKuPnIfBJekiXr+BHbbMjrWn/xqrDQuxFTeyA==",
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
+      "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "license": "MIT",
       "dependencies": {
-        "@asamuzakjp/dom-selector": "^2.0.1",
-        "cssstyle": "^4.0.1",
+        "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
-        "decimal.js": "^10.4.3",
-        "form-data": "^4.0.0",
+        "decimal.js": "^10.5.0",
         "html-encoding-sniffer": "^4.0.0",
-        "http-proxy-agent": "^7.0.0",
-        "https-proxy-agent": "^7.0.2",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
         "is-potential-custom-element-name": "^1.0.1",
-        "parse5": "^7.1.2",
-        "rrweb-cssom": "^0.6.0",
+        "nwsapi": "^2.2.16",
+        "parse5": "^7.2.1",
+        "rrweb-cssom": "^0.8.0",
         "saxes": "^6.0.0",
         "symbol-tree": "^3.2.4",
-        "tough-cookie": "^4.1.3",
+        "tough-cookie": "^5.1.1",
         "w3c-xmlserializer": "^5.0.0",
         "webidl-conversions": "^7.0.0",
         "whatwg-encoding": "^3.1.1",
         "whatwg-mimetype": "^4.0.0",
-        "whatwg-url": "^14.0.0",
-        "ws": "^8.16.0",
+        "whatwg-url": "^14.1.1",
+        "ws": "^8.18.0",
         "xml-name-validator": "^5.0.0"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
-        "canvas": "^2.11.2"
+        "canvas": "^3.0.0"
       },
       "peerDependenciesMeta": {
         "canvas": {
@@ -11673,15 +11466,6 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
-    "node_modules/load-yaml-file/node_modules/pify": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -11845,15 +11629,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/make-dir/node_modules/pify": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/make-dir/node_modules/semver": {
       "version": "5.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
@@ -11896,12 +11671,11 @@
       "license": "CC0-1.0"
     },
     "node_modules/media-chrome": {
-      "version": "4.11.1",
-      "resolved": "https://registry.npmjs.org/media-chrome/-/media-chrome-4.11.1.tgz",
-      "integrity": "sha512-+2niDc4qOwlpFAjwxg1OaizK/zKV6y7QqGm4nBFEVlSaG0ZBgOmfc4IXAPiirZqAlZGaFFUaMqCl1SpGU0/naA==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/media-chrome/-/media-chrome-4.13.1.tgz",
+      "integrity": "sha512-jPPwYrFkM4ky27/xNYEeyRPOBC7qvru4Oydy7vQHMHplXLQJmjtcauhlLPvG0O5kkYFEaOBXv5zGYes/UxOoVw==",
       "license": "MIT",
       "dependencies": {
-        "@vercel/edge": "^1.2.1",
         "ce-la-react": "^0.3.0"
       }
     },
@@ -12633,6 +12407,37 @@
       }
     },
     "node_modules/p-limit": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-7.1.1.tgz",
+      "integrity": "sha512-i8PyM2JnsNChVSYWLr2BAjNoLi0BAYC+wecOnZnVV+YSNJkzP7cWmvI34dk0WArWfH9KwBHNoZI3P3MppImlIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate/node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
@@ -12647,14 +12452,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/p-locate": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+    "node_modules/p-locate/node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "license": "MIT",
-      "dependencies": {
-        "p-limit": "^3.0.2"
-      },
       "engines": {
         "node": ">=10"
       },
@@ -12975,12 +12777,6 @@
         "xtend": "~4.0.1"
       }
     },
-    "node_modules/pend": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
-      "license": "MIT"
-    },
     "node_modules/performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
@@ -13006,33 +12802,12 @@
       }
     },
     "node_modules/pify": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
       "license": "MIT",
       "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/pinkie": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-      "integrity": "sha512-MnUuEycAemtSaeFSjXKW/aroV7akBbY+Sv+RkyqFjgAe73F+MR0TBWKBRDkmfWq/HiFmdavfZ1G7h4SPZXaCSg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/pinkie-promise": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-      "integrity": "sha512-0Gni6D4UcLTbv9c57DfxDGdr41XfgUjqWZu492f0cIGr16zDU06BWP/RAEvOuo7CQ0CNjHaLlM59YJJFm3NWlw==",
-      "license": "MIT",
-      "dependencies": {
-        "pinkie": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
+        "node": ">=6"
       }
     },
     "node_modules/pirates": {
@@ -13072,6 +12847,16 @@
         "media-chrome": "~4.11.0"
       }
     },
+    "node_modules/player.style/node_modules/media-chrome": {
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/media-chrome/-/media-chrome-4.11.1.tgz",
+      "integrity": "sha512-+2niDc4qOwlpFAjwxg1OaizK/zKV6y7QqGm4nBFEVlSaG0ZBgOmfc4IXAPiirZqAlZGaFFUaMqCl1SpGU0/naA==",
+      "license": "MIT",
+      "dependencies": {
+        "@vercel/edge": "^1.2.1",
+        "ce-la-react": "^0.3.0"
+      }
+    },
     "node_modules/pluralize-esm": {
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/pluralize-esm/-/pluralize-esm-9.0.5.tgz",
@@ -13097,6 +12882,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
       "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -13401,9 +13187,9 @@
       }
     },
     "node_modules/react-compiler-runtime": {
-      "version": "19.1.0-rc.2",
-      "resolved": "https://registry.npmjs.org/react-compiler-runtime/-/react-compiler-runtime-19.1.0-rc.2.tgz",
-      "integrity": "sha512-852AwyIsbWJ5o1LkQVAZsVK3iLjMxOfKZuxqeGd/RfD+j1GqHb6j3DSHLtpu4HhFbQHsP2DzxjJyKR6luv4D8w==",
+      "version": "19.1.0-rc.3",
+      "resolved": "https://registry.npmjs.org/react-compiler-runtime/-/react-compiler-runtime-19.1.0-rc.3.tgz",
+      "integrity": "sha512-Cssogys2XZu6SqxRdX2xd8cQAf57BBvFbLEBlIa77161lninbKUn/EqbecCe7W3eqDQfg3rIoOwzExzgCh7h/g==",
       "license": "MIT",
       "peerDependencies": {
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0 || ^0.0.0-experimental"
@@ -13509,13 +13295,13 @@
       }
     },
     "node_modules/react-rx": {
-      "version": "4.1.31",
-      "resolved": "https://registry.npmjs.org/react-rx/-/react-rx-4.1.31.tgz",
-      "integrity": "sha512-wRdAh4yQ+hQkkcHRH4CC8RnyZWtTx76lhbqCEfrdXOvl65twRuTi6vmMQM/tQj7jguiPxiVN2hEJkjXsd6pstw==",
+      "version": "4.1.32",
+      "resolved": "https://registry.npmjs.org/react-rx/-/react-rx-4.1.32.tgz",
+      "integrity": "sha512-UX807x4Q0carkJGEpnoyTC0VnHDazXA3fDNFVGdszyNGqOwxZYOCMpkuAIfOzuHr5G6b3rZv5Jo33mFaCUe7gA==",
       "license": "MIT",
       "dependencies": {
         "observable-callback": "^1.0.3",
-        "react-compiler-runtime": "19.1.0-rc.2",
+        "react-compiler-runtime": "19.1.0-rc.3",
         "use-effect-event": "^2.0.3"
       },
       "peerDependencies": {
@@ -13834,9 +13620,9 @@
       "license": "MIT"
     },
     "node_modules/regenerate-unicode-properties": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-10.2.0.tgz",
-      "integrity": "sha512-DqHn3DwbmmPVzeKj9woBadqmXxLvQoQIwu7nopMc72ztvxVmVk2SBhSnx67zuye5TP+lJsb/TBQsjLKhnDf3MA==",
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-10.2.2.tgz",
+      "integrity": "sha512-m03P+zhBeQd1RGnYxrGyDAPpWX/epKirLrp8e3qevZdVkKtnCrjjWczIbYc8+xd6vcTStVlqfycTx1KR4LOr0g==",
       "license": "MIT",
       "dependencies": {
         "regenerate": "^1.4.2"
@@ -13844,6 +13630,13 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",
@@ -13867,17 +13660,17 @@
       }
     },
     "node_modules/regexpu-core": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-6.2.0.tgz",
-      "integrity": "sha512-H66BPQMrv+V16t8xtmq+UC0CBpiTBA60V8ibS1QVReIp8T1z8hwFxqcGzm9K6lgsN7sB5edVH8a+ze6Fqm4weA==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-6.3.1.tgz",
+      "integrity": "sha512-DzcswPr252wEr7Qz8AyAVbfyBDKLoYp6eRA1We2Fa9qirRFSdtkP5sHr3yglDKy2BbA0fd2T+j/CUSKes3FeVQ==",
       "license": "MIT",
       "dependencies": {
         "regenerate": "^1.4.2",
-        "regenerate-unicode-properties": "^10.2.0",
+        "regenerate-unicode-properties": "^10.2.2",
         "regjsgen": "^0.8.0",
         "regjsparser": "^0.12.0",
         "unicode-match-property-ecmascript": "^2.0.0",
-        "unicode-match-property-value-ecmascript": "^2.1.0"
+        "unicode-match-property-value-ecmascript": "^2.2.1"
       },
       "engines": {
         "node": ">=4"
@@ -14018,9 +13811,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.49.0.tgz",
-      "integrity": "sha512-3IVq0cGJ6H7fKXXEdVt+RcYvRCt8beYY9K1760wGQwSAHZcS9eot1zDG5axUbcp/kWRi5zKIIDX8MoKv/TzvZA==",
+      "version": "4.50.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.50.1.tgz",
+      "integrity": "sha512-78E9voJHwnXQMiQdiqswVLZwJIzdBKJ1GdI5Zx6XwoFKUIk09/sSrr+05QFzvYb8q6Y9pPV45zzDuYa3907TZA==",
       "license": "MIT",
       "dependencies": {
         "@types/estree": "1.0.8"
@@ -14033,33 +13826,34 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.49.0",
-        "@rollup/rollup-android-arm64": "4.49.0",
-        "@rollup/rollup-darwin-arm64": "4.49.0",
-        "@rollup/rollup-darwin-x64": "4.49.0",
-        "@rollup/rollup-freebsd-arm64": "4.49.0",
-        "@rollup/rollup-freebsd-x64": "4.49.0",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.49.0",
-        "@rollup/rollup-linux-arm-musleabihf": "4.49.0",
-        "@rollup/rollup-linux-arm64-gnu": "4.49.0",
-        "@rollup/rollup-linux-arm64-musl": "4.49.0",
-        "@rollup/rollup-linux-loongarch64-gnu": "4.49.0",
-        "@rollup/rollup-linux-ppc64-gnu": "4.49.0",
-        "@rollup/rollup-linux-riscv64-gnu": "4.49.0",
-        "@rollup/rollup-linux-riscv64-musl": "4.49.0",
-        "@rollup/rollup-linux-s390x-gnu": "4.49.0",
-        "@rollup/rollup-linux-x64-gnu": "4.49.0",
-        "@rollup/rollup-linux-x64-musl": "4.49.0",
-        "@rollup/rollup-win32-arm64-msvc": "4.49.0",
-        "@rollup/rollup-win32-ia32-msvc": "4.49.0",
-        "@rollup/rollup-win32-x64-msvc": "4.49.0",
+        "@rollup/rollup-android-arm-eabi": "4.50.1",
+        "@rollup/rollup-android-arm64": "4.50.1",
+        "@rollup/rollup-darwin-arm64": "4.50.1",
+        "@rollup/rollup-darwin-x64": "4.50.1",
+        "@rollup/rollup-freebsd-arm64": "4.50.1",
+        "@rollup/rollup-freebsd-x64": "4.50.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.50.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.50.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.50.1",
+        "@rollup/rollup-linux-arm64-musl": "4.50.1",
+        "@rollup/rollup-linux-loongarch64-gnu": "4.50.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.50.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.50.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.50.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.50.1",
+        "@rollup/rollup-linux-x64-gnu": "4.50.1",
+        "@rollup/rollup-linux-x64-musl": "4.50.1",
+        "@rollup/rollup-openharmony-arm64": "4.50.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.50.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.50.1",
+        "@rollup/rollup-win32-x64-msvc": "4.50.1",
         "fsevents": "~2.3.2"
       }
     },
     "node_modules/rrweb-cssom": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.6.0.tgz",
-      "integrity": "sha512-APM0Gt1KoXBz0iIkkdB/kfvGOwC4UuJFeG/c+yV7wSc7q96cG/kJ0HiYCnzivD9SB53cLV1MlHFNfOuPaadYSw==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
       "license": "MIT"
     },
     "node_modules/run-async": {
@@ -14246,51 +14040,52 @@
       "license": "MIT"
     },
     "node_modules/sanity": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/sanity/-/sanity-4.6.0.tgz",
-      "integrity": "sha512-xO6f2AMCzki2GwnQFYdikeEd3kf5sQT8AUhArAOtoI5E6cA64YZ2UHLRwCABmm+sLa2/ynE1V4b/fSw19EGSgw==",
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/sanity/-/sanity-4.8.1.tgz",
+      "integrity": "sha512-yp+sYeONUuCsTEeadpyidEOSK6SVuQ16RlfJK+wV9TZSdxwuJpYhTbmz2HOTsx9aW/wO/w2Nkrk/HyaxC6npBg==",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/modifiers": "^6.0.1",
         "@dnd-kit/sortable": "^7.0.2",
         "@dnd-kit/utilities": "^3.2.2",
+        "@isaacs/ttlcache": "^1.4.1",
         "@juggle/resize-observer": "^3.4.0",
-        "@mux/mux-player-react": "^3.5.3",
-        "@portabletext/block-tools": "^3.3.3",
-        "@portabletext/editor": "^2.6.3",
-        "@portabletext/react": "^4.0.1",
-        "@portabletext/toolkit": "^3.0.0",
+        "@mux/mux-player-react": "^3.6.0",
+        "@portabletext/block-tools": "^3.5.4",
+        "@portabletext/editor": "^2.8.3",
+        "@portabletext/react": "^4.0.3",
+        "@portabletext/toolkit": "^3.0.1",
         "@rexxars/react-json-inspector": "^9.0.1",
         "@sanity/asset-utils": "^2.2.1",
         "@sanity/bifur-client": "^0.4.1",
-        "@sanity/cli": "4.6.0",
-        "@sanity/client": "^7.9.0",
+        "@sanity/cli": "4.8.1",
+        "@sanity/client": "^7.11.1",
         "@sanity/color": "^3.0.6",
         "@sanity/comlink": "^3.0.9",
-        "@sanity/diff": "4.6.0",
+        "@sanity/diff": "4.8.1",
         "@sanity/diff-match-patch": "^3.2.0",
         "@sanity/diff-patch": "^5.0.0",
         "@sanity/eventsource": "^5.0.2",
         "@sanity/export": "^4.0.1",
         "@sanity/icons": "^3.7.4",
         "@sanity/id-utils": "^1.0.0",
-        "@sanity/image-url": "^1.1.0",
+        "@sanity/image-url": "^1.2.0",
         "@sanity/import": "^3.38.3",
-        "@sanity/insert-menu": "^2.0.1",
+        "@sanity/insert-menu": "^2.0.2",
         "@sanity/logos": "^2.2.2",
         "@sanity/media-library-types": "^1.0.0",
         "@sanity/message-protocol": "^0.17.2",
-        "@sanity/migrate": "4.6.0",
-        "@sanity/mutator": "4.6.0",
-        "@sanity/presentation-comlink": "^1.0.28",
-        "@sanity/preview-url-secret": "^2.1.14",
-        "@sanity/schema": "4.6.0",
+        "@sanity/migrate": "4.8.1",
+        "@sanity/mutator": "4.8.1",
+        "@sanity/presentation-comlink": "^1.0.29",
+        "@sanity/preview-url-secret": "^2.1.15",
+        "@sanity/schema": "4.8.1",
         "@sanity/sdk": "2.1.2",
         "@sanity/telemetry": "^0.8.0",
-        "@sanity/types": "4.6.0",
-        "@sanity/ui": "^3.0.7",
-        "@sanity/util": "4.6.0",
+        "@sanity/types": "4.8.1",
+        "@sanity/ui": "^3.0.14",
+        "@sanity/util": "4.8.1",
         "@sanity/uuid": "^3.0.2",
         "@sentry/react": "^8.55.0",
         "@tanstack/react-table": "^8.21.3",
@@ -14324,7 +14119,7 @@
         "framer-motion": "^12.23.12",
         "get-it": "^8.6.10",
         "get-random-values-esm": "1.0.2",
-        "groq-js": "^1.17.3",
+        "groq-js": "^1.18.0",
         "gunzip-maybe": "^1.4.2",
         "history": "^5.3.0",
         "i18next": "^23.16.8",
@@ -14358,13 +14153,13 @@
         "pretty-ms": "^7.0.1",
         "quick-lru": "^5.1.1",
         "raf": "^3.4.1",
-        "react-compiler-runtime": "19.1.0-rc.2",
+        "react-compiler-runtime": "19.1.0-rc.3",
         "react-fast-compare": "^3.2.2",
         "react-focus-lock": "^2.13.6",
         "react-i18next": "15.6.1",
         "react-is": "^19.1.1",
         "react-refractor": "^4.0.0",
-        "react-rx": "^4.1.31",
+        "react-rx": "^4.1.32",
         "read-pkg-up": "^7.0.1",
         "refractor": "^5.0.0",
         "resolve-from": "^5.0.0",
@@ -14387,9 +14182,9 @@
         "use-hot-module-reload": "^2.0.0",
         "use-sync-external-store": "^1.5.0",
         "uuid": "^11.1.0",
-        "vite": "^7.1.3",
+        "vite": "^7.1.5",
         "which": "^5.0.0",
-        "xstate": "^5.20.2",
+        "xstate": "^5.21.0",
         "yargs": "^17.7.2"
       },
       "bin": {
@@ -14413,6 +14208,46 @@
         "node": ">=16"
       }
     },
+    "node_modules/sanity/node_modules/jsdom": {
+      "version": "23.2.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-23.2.0.tgz",
+      "integrity": "sha512-L88oL7D/8ufIES+Zjz7v0aes+oBMh2Xnh3ygWvL0OaICOomKEPKuPnIfBJekiXr+BHbbMjrWn/xqrDQuxFTeyA==",
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/dom-selector": "^2.0.1",
+        "cssstyle": "^4.0.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.2",
+        "is-potential-custom-element-name": "^1.0.1",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.6.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^4.1.3",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.16.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^2.11.2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/sanity/node_modules/resolve-from": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -14421,6 +14256,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/sanity/node_modules/rrweb-cssom": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.6.0.tgz",
+      "integrity": "sha512-APM0Gt1KoXBz0iIkkdB/kfvGOwC4UuJFeG/c+yV7wSc7q96cG/kJ0HiYCnzivD9SB53cLV1MlHFNfOuPaadYSw==",
+      "license": "MIT"
     },
     "node_modules/sanity/node_modules/semver": {
       "version": "7.7.2",
@@ -14432,6 +14273,21 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/sanity/node_modules/tough-cookie": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/sanity/node_modules/uuid": {
@@ -14495,19 +14351,6 @@
       "integrity": "sha512-UkEHHOV6j5cE3IsObQRK6vO4twSuhE4vtLD4UmX+doHgrtg2jRwXkz4O6cz0jcoxK5NGU7rFjyvLcWHzw7eQ5A==",
       "license": "MIT"
     },
-    "node_modules/seek-bzip": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.6.tgz",
-      "integrity": "sha512-e1QtP3YL5tWww8uKaOCQ18UxIT2laNBXHjV/S2WYCiK4udiv8lkG89KRIoCjUagnAmCBurjF4zEVX2ByBbnCjQ==",
-      "license": "MIT",
-      "dependencies": {
-        "commander": "^2.8.1"
-      },
-      "bin": {
-        "seek-bunzip": "bin/seek-bunzip",
-        "seek-table": "bin/seek-bzip-table"
-      }
-    },
     "node_modules/semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
@@ -14521,6 +14364,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
       "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.1.4",
@@ -15179,15 +15023,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/strip-dirs": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-2.1.0.tgz",
-      "integrity": "sha512-JOCxOeKLm2CAS73y/U4ZeZPTkE+gNVCzKt7Eox84Iej1LT/2pTWYpZKJuxwQpvX1LiZb1xokNR7RLfuBAa7T3g==",
-      "license": "MIT",
-      "dependencies": {
-        "is-natural-number": "^4.0.1"
-      }
-    },
     "node_modules/strip-final-newline": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
@@ -15398,12 +15233,6 @@
         "b4a": "^1.6.4"
       }
     },
-    "node_modules/through": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
-      "license": "MIT"
-    },
     "node_modules/through2": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
@@ -15440,13 +15269,13 @@
       "license": "MIT"
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.14",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
-      "integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
       "license": "MIT",
       "dependencies": {
-        "fdir": "^6.4.4",
-        "picomatch": "^4.0.2"
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -15473,20 +15302,6 @@
       "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
       "license": "MIT"
     },
-    "node_modules/to-buffer": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.1.tgz",
-      "integrity": "sha512-tB82LpAIWjhLYbqjx3X4zEeHN6M8CiuOEy2JY8SEQVdYRe3CCHOFaqrBW1doLDrfpWhplcW7BL+bO3/6S3pcDQ==",
-      "license": "MIT",
-      "dependencies": {
-        "isarray": "^2.0.5",
-        "safe-buffer": "^5.2.1",
-        "typed-array-buffer": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -15500,18 +15315,15 @@
       }
     },
     "node_modules/tough-cookie": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
-      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "psl": "^1.1.33",
-        "punycode": "^2.1.1",
-        "universalify": "^0.2.0",
-        "url-parse": "^1.5.3"
+        "tldts": "^6.1.32"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=16"
       }
     },
     "node_modules/tr46": {
@@ -15644,6 +15456,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
       "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
@@ -15798,16 +15611,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/unbzip2-stream": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
-      "integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
-      "license": "MIT",
-      "dependencies": {
-        "buffer": "^5.2.1",
-        "through": "^2.3.8"
-      }
-    },
     "node_modules/undici": {
       "version": "5.29.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
@@ -15849,9 +15652,9 @@
       }
     },
     "node_modules/unicode-match-property-value-ecmascript": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-2.2.0.tgz",
-      "integrity": "sha512-4IehN3V/+kkr5YeSSDDQG8QLqO26XpL2XP3GQtqwlT/QYSECAwFztxVHjlbh0+gjJ3XmNLS0zDsbgs9jWKExLg==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-2.2.1.tgz",
+      "integrity": "sha512-JQ84qTuMg4nVkx8ga4A16a1epI9H6uTXAknqxkGF/aFfRLw1xC/Bp24HNLaZhHSkWd3+84t8iXnp1J0kYcZHhg==",
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -16126,19 +15929,10 @@
         "spdx-expression-parse": "^3.0.0"
       }
     },
-    "node_modules/validate-npm-package-name": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
-      "integrity": "sha512-M6w37eVCMMouJ9V/sdPGnC5H4uDr73/+xdq0FBLO3TFFX1+7wiUY6Es328NN+y43tmY+doUdN9g9J21vqB7iLw==",
-      "license": "ISC",
-      "dependencies": {
-        "builtins": "^1.0.3"
-      }
-    },
     "node_modules/vite": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.3.tgz",
-      "integrity": "sha512-OOUi5zjkDxYrKhTV3V7iKsoS37VUM7v40+HuwEmcrsf11Cdx9y3DIr2Px6liIcZFwt3XSRpQvFpL3WVy7ApkGw==",
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.5.tgz",
+      "integrity": "sha512-4cKBO9wR75r0BeIWWWId9XK9Lj6La5X846Zw9dFfzMRw38IlTk2iCcUt6hsyiDRcPidc55ZParFYDXi0nXOeLQ==",
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.25.0",
@@ -16146,7 +15940,7 @@
         "picomatch": "^4.0.3",
         "postcss": "^8.5.6",
         "rollup": "^4.43.0",
-        "tinyglobby": "^0.2.14"
+        "tinyglobby": "^0.2.15"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -16433,6 +16227,7 @@
       "version": "1.1.19",
       "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz",
       "integrity": "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
@@ -16477,6 +16272,19 @@
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
       "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
       "license": "MIT"
+    },
+    "node_modules/wp-types": {
+      "version": "4.68.1",
+      "resolved": "https://registry.npmjs.org/wp-types/-/wp-types-4.68.1.tgz",
+      "integrity": "sha512-PpyF5va7pxdBSV8cE3oao/Wfsrbx1gZKmBaijOd6/Q6RmuzCfUSPHtj8RzAtwDYD8dv7cga5lX63TvYTHdOIZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "typescript": ">=4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/johnbillion"
+      }
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
@@ -16712,32 +16520,13 @@
         "node": ">=12"
       }
     },
-    "node_modules/yauzl": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
-      "license": "MIT",
-      "dependencies": {
-        "buffer-crc32": "~0.2.3",
-        "fd-slicer": "~1.1.0"
-      }
-    },
-    "node_modules/yauzl/node_modules/buffer-crc32": {
-      "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/yocto-queue": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
-      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.1.tgz",
+      "integrity": "sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==",
       "license": "MIT",
       "engines": {
-        "node": ">=10"
+        "node": ">=12.20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "@sanity/icons": "^3.7.4",
         "@sanity/vision": "^4.6.0",
-        "dotenv": "^17.2.1",
         "react": "^19.1",
         "react-dom": "^19.1",
         "sanity": "^4.6.0",
@@ -19,7 +18,6 @@
       },
       "devDependencies": {
         "@sanity/eslint-config-studio": "^5.0.2",
-        "@types/dotenv": "^6.1.1",
         "@types/react": "^19.1",
         "eslint": "^9.28",
         "prettier": "^3.5",
@@ -5766,16 +5764,6 @@
         "@babel/types": "^7.28.2"
       }
     },
-    "node_modules/@types/dotenv": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/@types/dotenv/-/dotenv-6.1.1.tgz",
-      "integrity": "sha512-ftQl3DtBvqHl9L16tpqqzA4YzCSXZfi7g8cQceTz5rOlYtk/IZbFjAv3mLOQlNIgOaylCQWQoBdDQHPgEBJPHg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -8353,18 +8341,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/dotenv": {
-      "version": "17.2.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.1.tgz",
-      "integrity": "sha512-kQhDYKZecqnM0fCnzI5eIv5L4cAe/iRI+HqMbO/hbRdTAeXDG+M9FjipUxNfbARuEg4iHIbhnhs78BCHNbSxEQ==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/package.json
+++ b/package.json
@@ -16,18 +16,24 @@
   ],
   "dependencies": {
     "@sanity/icons": "^3.7.4",
-    "@sanity/vision": "^4.6.0",
+    "@sanity/vision": "^4.8.1",
     "react": "^19.1",
     "react-dom": "^19.1",
-    "sanity": "^4.6.0",
+    "sanity": "^4.8.1",
     "styled-components": "^6.1.18"
   },
   "devDependencies": {
+    "@portabletext/block-tools": "^3.5.5",
     "@sanity/eslint-config-studio": "^5.0.2",
     "@types/react": "^19.1",
+    "@wordpress/block-serialization-default-parser": "^5.30.0",
     "eslint": "^9.28",
+    "html-entities": "^2.6.0",
+    "jsdom": "^26.1.0",
+    "p-limit": "^7.1.1",
     "prettier": "^3.5",
-    "typescript": "^5.8"
+    "typescript": "^5.8",
+    "wp-types": "^4.68.1"
   },
   "prettier": {
     "semi": false,

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
   "dependencies": {
     "@sanity/icons": "^3.7.4",
     "@sanity/vision": "^4.6.0",
-    "dotenv": "^17.2.1",
     "react": "^19.1",
     "react-dom": "^19.1",
     "sanity": "^4.6.0",
@@ -25,7 +24,6 @@
   },
   "devDependencies": {
     "@sanity/eslint-config-studio": "^5.0.2",
-    "@types/dotenv": "^6.1.1",
     "@types/react": "^19.1",
     "eslint": "^9.28",
     "prettier": "^3.5",

--- a/sanity.cli.ts
+++ b/sanity.cli.ts
@@ -1,11 +1,9 @@
-import {config as dotenvConfig} from 'dotenv'
-dotenvConfig()
 import {defineCliConfig} from 'sanity/cli'
 
 export default defineCliConfig({
   api: {
-    projectId: process.env.SANITY_PROJECT_ID || 'default_id',
-    dataset: process.env.SANITY_DATASET || 'production',
+    projectId: process.env.SANITY_STUDIO_PROJECT_ID || 'project_id',
+    dataset: process.env.SANITY_STUDIO_DATASET || 'production',
   },
   /**
    * Enable auto-updates for studios.

--- a/sanity.config.ts
+++ b/sanity.config.ts
@@ -1,3 +1,8 @@
+// Load environment variables only in Node.js environment
+if (typeof window === 'undefined') {
+  require('dotenv').config()
+}
+
 import {defineConfig} from 'sanity'
 import {structureTool} from 'sanity/structure'
 import {visionTool} from '@sanity/vision'
@@ -7,8 +12,8 @@ export default defineConfig({
   name: 'default',
   title: 'Sanity WordPress',
 
-  projectId: 'qldrpv59',
-  dataset: 'production',
+  projectId: process.env.SANITY_STUDIO_PROJECT_ID || 'project_id',
+  dataset: process.env.SANITY_STUDIO_DATASET || 'production',
 
   plugins: [structureTool(), visionTool()],
 


### PR DESCRIPTION
This pull request introduces a migration utility to import WordPress posts into Sanity, along with supporting type definitions, API helpers, and configuration improvements. The main focus is on automating the import process from a WordPress REST API, ensuring type safety, and updating environment variable usage for project configuration.

**WordPress Import Migration:**

* Added a migration script (`index.ts`) that fetches paginated `posts` from the WordPress API and imports them into Sanity as `post` documents using the `createOrReplace` method.
* Implemented a helper function (`wpDataTypeFetch.ts`) to fetch paginated data for any WordPress data type from the API, using constants for the base URL and pagination size. [[1]](diffhunk://#diff-a68b6ecbdf985802fdceb174cfa3f4cca973c3205445294b1f602960fa6b71f2R1-R13) [[2]](diffhunk://#diff-143d7f3f0a121b7bae69869a7afc3b3b55058d45c14e7003abe87f20dd4022aaR1-R3)
* Defined TypeScript types (`types.ts`) for supported WordPress data types and their responses, leveraging the `wp-types` package for type safety.

**Configuration and Environment Variables:**

* Updated environment variable usage in `sanity.config.ts` and `sanity.cli.ts` to use `SANITY_STUDIO_PROJECT_ID` and `SANITY_STUDIO_DATASET`, with fallback values for local development. Also, ensured dotenv is loaded only in Node.js environments. [[1]](diffhunk://#diff-fc38307d4c98cb8f9b2dc6b8a748bc5b64b62a63ef1e871fae4c10af57abb141R1-R5) [[2]](diffhunk://#diff-fc38307d4c98cb8f9b2dc6b8a748bc5b64b62a63ef1e871fae4c10af57abb141L10-R16) [[3]](diffhunk://#diff-8e5d09f5ceefa2b5b5172289ebfa6ab293666c5e4e4b95498d0b47abb9b7c030L1-R6)

**Dependency Updates:**

* Added new dependencies for WordPress types and utilities, and updated several Sanity-related packages to their latest versions in `package.json`.